### PR TITLE
Added venture tree rebuild when venture plugin job is finished

### DIFF
--- a/src/ralph_pricing/plugins/collects/ventures.py
+++ b/src/ralph_pricing/plugins/collects/ventures.py
@@ -35,4 +35,5 @@ def ventures(**kwargs):
     """Updates the ventures from Ralph."""
 
     count = sum(update_venture(data) for data in api_pricing.get_ventures())
+    Venture.tree.rebuild()
     return True, '%d new ventures' % count, kwargs


### PR DESCRIPTION
added venture tree rebuild when plugin job is finished. After ventures collecting is finished, whole tree is rebuilded to fix possible problems with ventures tree (ex. left_id and right_id in mptt were improperly calculated).
