### PR TITLE
fixed unicode of dynamic extra cost

### DIFF
--- a/src/ralph_scrooge/models/extra_cost.py
+++ b/src/ralph_scrooge/models/extra_cost.py
@@ -189,7 +189,7 @@ class DynamicExtraCost(db.Model):
 
     def __unicode__(self):
         return '{} ({}-{})'.format(
-            self.extra_cost_type,
+            self.dynamic_extra_cost_type,
             self.start,
             self.end,
         )
@@ -212,7 +212,7 @@ class SupportCost(AbstractExtraCost):
         app_label = 'ralph_scrooge'
 
     def __unicode__(self):
-        return 'Support: {} ({} - {})'.format(
+        return '{} ({} - {})'.format(
             self.pricing_object.name,
             self.start,
             self.end,

--- a/src/ralph_scrooge/tests/test_models.py
+++ b/src/ralph_scrooge/tests/test_models.py
@@ -14,10 +14,13 @@ from ralph_scrooge.tests import ScroogeTestCase
 from ralph_scrooge.tests.models import History, HistoricalHistory
 from ralph_scrooge.tests.utils.factory import (
     DailyPricingObjectFactory,
+    DynamicExtraCostFactory,
+    ExtraCostFactory,
     ExtraCostTypeFactory,
     PricingObjectFactory,
     PricingServiceFactory,
     ServiceEnvironmentFactory,
+    SupportCostFactory,
     UsageTypeFactory,
     WarehouseFactory,
 )
@@ -281,3 +284,31 @@ class TestDailyCost(ScroogeTestCase):
         )
         for t in tree_flat:
             self.assertIn(t, daily_costs_dicts)
+
+
+class TestModelRepr(ScroogeTestCase):
+    def test_extra_cost(self):
+        extra_cost = ExtraCostFactory()
+        result = unicode(extra_cost)
+        self.assertEqual(result, '{} - {}'.format(
+            extra_cost.service_environment,
+            extra_cost.extra_cost_type
+        ))
+
+    def test_dynamic_extra_cost(self):
+        dynamic_extra_cost = DynamicExtraCostFactory()
+        result = unicode(dynamic_extra_cost)
+        self.assertEqual(result, '{} ({}-{})'.format(
+            dynamic_extra_cost.dynamic_extra_cost_type,
+            dynamic_extra_cost.start,
+            dynamic_extra_cost.end,
+        ))
+
+    def test_support(self):
+        support_cost = SupportCostFactory()
+        result = unicode(support_cost)
+        self.assertEqual(result, '{} ({} - {})'.format(
+            support_cost.pricing_object.name,
+            support_cost.start,
+            support_cost.end,
+        ))

--- a/src/ralph_scrooge/tests/utils/factory.py
+++ b/src/ralph_scrooge/tests/utils/factory.py
@@ -239,6 +239,17 @@ class ExtraCostFactory(DjangoModelFactory):
     end = datetime.date.today()
 
 
+class SupportCostFactory(DjangoModelFactory):
+    FACTORY_FOR = models.SupportCost
+
+    extra_cost_type = SubFactory(ExtraCostTypeFactory)
+    cost = 100
+    start = datetime.date.today()
+    end = datetime.date.today()
+    support_id = Sequence(lambda n: n)
+    pricing_object = SubFactory(PricingObjectFactory)
+
+
 class DynamicExtraCostTypeFactory(DjangoModelFactory):
     FACTORY_FOR = models.DynamicExtraCostType
 


### PR DESCRIPTION
changed DynamicExtraCost object representation method (__unicode__) - replaced extra_cost_type by dynamic_extra_cost_type, which is valid field of DynamicExtraCost. Added some unit tests to test it as well.