### PR TITLE
Added column alias possibility in components view

### DIFF
--- a/src/ralph_scrooge/settings.py
+++ b/src/ralph_scrooge/settings.py
@@ -50,22 +50,35 @@ TESTING = 'test' in sys.argv
 
 COMPONENTS_TABLE_SCHEMA = {
     'Asset': {
-        'fields': ['id', 'name', 'assetinfo.sn', 'assetinfo.barcode'],
+        'fields': [
+            'pricing_object.id',
+            'pricing_object.name',
+            'pricing_object.assetinfo.sn',
+            'pricing_object.assetinfo.barcode'
+        ],
         'model': 'ralph_scrooge.models.DailyAssetInfo',
     },
     'Virtual': {
-        'fields': ['id', 'name', 'virtualinfo.device_id'],
+        'fields': [
+            'pricing_object.id',
+            'pricing_object.name',
+            'pricing_object.model.name',
+            ('dailyvirtualinfo.hypervisor.pricing_object.name', 'Hypervisor'),
+        ],
         'model': 'ralph_scrooge.models.DailyVirtualInfo',
     },
     'IP Address': {
-        'fields': ['id', 'name'],
+        'fields': [
+            'pricing_object.id',
+            'pricing_object.name'
+        ],
     },
     'OpenStack Tenant': {
         'fields': [
-            'id',
-            'name',
-            'tenantinfo.tenant_id',
-            'tenantinfo.device_id',
+            'pricing_object.id',
+            'pricing_object.name',
+            'pricing_object.tenantinfo.tenant_id',
+            'pricing_object.model.name',
         ],
         'model': 'ralph_scrooge.models.DailyTenantInfo',
     }

--- a/src/ralph_scrooge/tests/rest/test_components.py
+++ b/src/ralph_scrooge/tests/rest/test_components.py
@@ -124,8 +124,26 @@ class TestComponents(TestCase):
             '3': 'Barcode',
         })
 
+    def test_get_headers_with_alias(self):
+        fields = ['id', 'name', 'assetinfo.sn', ('assetinfo.barcode', 'Alias')]
+        headers = components._get_headers(
+            models.DailyAssetInfo,
+            fields,
+            prefix='pricing_object',
+        )
+        self.assertEquals(headers, {
+            '0': 'Id',
+            '1': 'Name',
+            '2': 'Serial Number',
+            '3': 'Alias',
+        })
+
     @override_settings(COMPONENTS_TABLE_SCHEMA={'Asset': {
-        'fields': ['id', 'name', 'service_environment.service.name'],
+        'fields': [
+            'pricing_object.id',
+            'pricing_object.name',
+            ('service_environment.service.name', 'Serv')
+        ],
         'model': 'ralph_scrooge.models.DailyAssetInfo',
     }})
     def test_process_single_type(self):
@@ -149,7 +167,7 @@ class TestComponents(TestCase):
             'schema': {
                 '0': 'Id',
                 '1': 'Name',
-                '2': 'Name',
+                '2': 'Serv',
             },
             'color': asset_type.color,
         })


### PR DESCRIPTION
Added possibility to specify column (field header) alias in components view by passing tuple of 2 strings instead of one string in COMPONENTS_TABLE_SCHEMA type fields.