### PR TITLE
removed limiting choices in ServiceUsageType.usage_type

### DIFF
--- a/src/ralph_scrooge/models/service.py
+++ b/src/ralph_scrooge/models/service.py
@@ -273,7 +273,6 @@ class ServiceUsageTypes(db.Model):
         'UsageType',
         verbose_name=_("Usage type"),
         related_name="service_division",
-        limit_choices_to=db.Q(usage_type='SU') | db.Q(symbol='depreciation'),
     )
     pricing_service = db.ForeignKey(
         PricingService,


### PR DESCRIPTION
removed limiting choices to allow to choose one of base usage types (ex. network, collocation) as a method of pricing service costs distribution