### PR TITLE
improved caching on all cost types calculation

### DIFF
--- a/src/ralph_scrooge/plugins/cost/base.py
+++ b/src/ralph_scrooge/plugins/cost/base.py
@@ -49,13 +49,34 @@ class BaseCostPlugin(BasePlugin):
                 return func(*args, **kwargs)
         raise AttributeError()
 
+    def costs(self, service_environments=None, *args, **kwargs):
+        """
+        Return information about costs of some type (ex. team, service)
+        filtered by passed service environments (if passed - otherwise it's
+        simple proxt to _costs method, which should be cached).
+        """
+        costs = self._costs(*args, **kwargs)
+        # filter by service environments if specified
+        if service_environments:
+            se_ids = set([se.id for se in service_environments])
+            costs = {k: v for (k, v) in costs.iteritems() if k in se_ids}
+        return costs
+
     @abc.abstractmethod
-    def costs(self, *args, **kwargs):
+    def _costs(self, *args, **kwargs):
         """
-        Should returns information about costs of usage (ex. team, service) per
-        service environment in format accepted by collector.
+        Should returns information about costs of some type (ex. team, service)
+        per service environment in format accepted by collector (dictionary,
+        with service_environment id as a key and value is list dictonaries with
+        costs definition. Example of single cost:
+        {
+            'cost': Decimal('100.12'),
+            'value': 300.12,  # usage of resource/type
+            'pricing_object_id': 1234  # optional, but it's preffered to return
+                here dummy pricing object id if concrete is not known
+            'type_id': 11,
+        }
         """
-        pass
 
     def total_cost(self, *args, **kwargs):
         """

--- a/src/ralph_scrooge/plugins/cost/dynamic_extra_cost.py
+++ b/src/ralph_scrooge/plugins/cost/dynamic_extra_cost.py
@@ -11,6 +11,7 @@ from ralph_scrooge.models import DynamicExtraCost
 from ralph_scrooge.plugins.base import register
 from ralph_scrooge.plugins.cost.base import NoPriceCostError
 from ralph_scrooge.plugins.cost.pricing_service import PricingServiceBasePlugin
+from ralph_scrooge.utils.common import memoize
 
 logger = logging.getLogger(__name__)
 
@@ -21,11 +22,11 @@ class DynamicExtraCostPlugin(PricingServiceBasePlugin):
         service_costs = self.costs(*args, **kwargs)
         return self._get_total_costs_from_costs(service_costs)
 
-    def costs(
+    @memoize(skip_first=True)
+    def _costs(
         self,
         dynamic_extra_cost_type,
         date,
-        service_environments,
         forecast=False,
         **kwargs
     ):
@@ -43,7 +44,6 @@ class DynamicExtraCostPlugin(PricingServiceBasePlugin):
         return self._distribute_costs(
             date,
             dynamic_extra_cost_type,
-            service_environments,
             costs,
             percentage,
             excluded_services=set(

--- a/src/ralph_scrooge/plugins/cost/extra_cost.py
+++ b/src/ralph_scrooge/plugins/cost/extra_cost.py
@@ -10,9 +10,8 @@ from collections import defaultdict
 
 from ralph_scrooge.models import ExtraCost
 from ralph_scrooge.plugins.base import register
-from ralph_scrooge.plugins.cost.base import (
-    BaseCostPlugin,
-)
+from ralph_scrooge.plugins.cost.base import BaseCostPlugin
+from ralph_scrooge.utils.common import memoize
 
 logger = logging.getLogger(__name__)
 
@@ -24,10 +23,10 @@ class ExtraCostPlugin(BaseCostPlugin):
     cost model.
     """
 
-    def costs(
+    @memoize(skip_first=True)
+    def _costs(
         self,
         date,
-        service_environments,
         extra_cost_type,
         forecast=False,
         *args,
@@ -56,7 +55,6 @@ class ExtraCostPlugin(BaseCostPlugin):
         extra_costs = ExtraCost.objects.filter(
             end__gte=date,
             start__lte=date,
-            service_environment__in=service_environments,
             extra_cost_type=extra_cost_type,
         )
 

--- a/src/ralph_scrooge/plugins/cost/pricing_service_fixed_price.py
+++ b/src/ralph_scrooge/plugins/cost/pricing_service_fixed_price.py
@@ -11,8 +11,8 @@ from decimal import Decimal as D
 
 from ralph.util import plugin as plugin_runner
 from ralph_scrooge.plugins.base import register
-from ralph_scrooge.plugins.cost.collector import Collector
 from ralph_scrooge.plugins.cost.pricing_service import PricingServiceBasePlugin
+from ralph_scrooge.utils.common import memoize
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +28,11 @@ class PricingServiceFixedPricePlugin(PricingServiceBasePlugin):
         service_costs = self.costs(*args, **kwargs)
         return self._get_total_costs_from_costs(service_costs)
 
-    def costs(
+    @memoize(skip_first=True)
+    def _costs(
         self,
         pricing_service,
         date,
-        service_environments,
         forecast=False,
         **kwargs
     ):
@@ -45,10 +45,6 @@ class PricingServiceFixedPricePlugin(PricingServiceBasePlugin):
             )
         )
         result_dict = defaultdict(dict)
-        # if service_environments are not defined, use all (usefull when
-        # calculating diff between real and calculated costs)
-        if not service_environments:
-            service_environments = Collector._get_services_environments()
         usage_types = pricing_service.usage_types.all()
         for usage_type in usage_types:
             try:
@@ -61,7 +57,6 @@ class PricingServiceFixedPricePlugin(PricingServiceBasePlugin):
                     date=date,
                     usage_type=usage_type,
                     forecast=forecast,
-                    service_environments=service_environments,
                 )
                 # store costs in hierarchy service environment / pricing object
                 # and calculate total cost of cloud per pricing object

--- a/src/ralph_scrooge/plugins/cost/support.py
+++ b/src/ralph_scrooge/plugins/cost/support.py
@@ -11,6 +11,7 @@ from collections import defaultdict, namedtuple
 from ralph_scrooge.models import ExtraCostType, SupportCost
 from ralph_scrooge.plugins.base import register
 from ralph_scrooge.plugins.cost.base import BaseCostPlugin
+from ralph_scrooge.utils.common import memoize
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +36,10 @@ class SupportPlugin(BaseCostPlugin):
     cost model.
     """
 
-    def costs(
+    @memoize(skip_first=True)
+    def _costs(
         self,
         date,
-        service_environments,
         forecast=False,
         *args,
         **kwargs
@@ -67,9 +68,6 @@ class SupportPlugin(BaseCostPlugin):
             end__gte=date,
             start__lte=date,
             pricing_object__daily_pricing_objects__date=date,
-            pricing_object__daily_pricing_objects__service_environment__in=(
-                service_environments
-            )
         ).values_list(
             'pricing_object__daily_pricing_objects__service_environment_id',
             'pricing_object_id',

--- a/src/ralph_scrooge/plugins/cost/usage_type.py
+++ b/src/ralph_scrooge/plugins/cost/usage_type.py
@@ -30,7 +30,6 @@ class UsageTypeBasePlugin(BaseCostPlugin):
         usage_type,
         forecast=False,
         warehouse=None,
-        service_environments=None,
         excluded_services=None,
         excluded_services_environments=None,
     ):
@@ -77,7 +76,6 @@ class UsageTypeBasePlugin(BaseCostPlugin):
         usage_type,
         date,
         forecast,
-        service_environments,
     ):
         """
         Returns information about usage (of usage type) count and cost
@@ -101,7 +99,6 @@ class UsageTypeBasePlugin(BaseCostPlugin):
             usages = self._get_usages_per_pricing_object(
                 date=date,
                 usage_type=usage_type,
-                service_environments=service_environments,
                 warehouse=warehouse,
                 excluded_services_environments=excluded_services_envs,
             )
@@ -121,10 +118,10 @@ class UsageTypeBasePlugin(BaseCostPlugin):
 
         return result
 
-    def costs(
+    @memoize(skip_first=True)
+    def _costs(
         self,
         date,
-        service_environments,
         usage_type,
         forecast=False,
         **kwargs
@@ -162,7 +159,6 @@ class UsageTypeBasePlugin(BaseCostPlugin):
         ))
         return self._get_costs_per_warehouse(
             date=date,
-            service_environments=service_environments,
             usage_type=usage_type,
             forecast=forecast,
         )

--- a/src/ralph_scrooge/tests/plugins/cost/test_base_cost_plugin.py
+++ b/src/ralph_scrooge/tests/plugins/cost/test_base_cost_plugin.py
@@ -22,7 +22,7 @@ from ralph_scrooge.tests.utils.factory import (
 
 
 class SampleCostPlugin(BaseCostPlugin):
-    def costs(self, *args, **kwargs):
+    def _costs(self, *args, **kwargs):
         pass
 
 

--- a/src/ralph_scrooge/tests/plugins/cost/test_ceilometer.py
+++ b/src/ralph_scrooge/tests/plugins/cost/test_ceilometer.py
@@ -56,13 +56,12 @@ class TestPricingServiceFixedPricePluginPlugin(TestCase):
             date,
             usage_type,
             forecast,
-            service_environments,
             *args,
             **kwargs
         ):
             if usage_type == self.service_usage_types[0]:
                 return {
-                    1: [
+                    self.service_environments[0].id: [
                         {
                             'pricing_object_id': 1,
                             'type_id': self.service_usage_types[0].id,
@@ -76,7 +75,7 @@ class TestPricingServiceFixedPricePluginPlugin(TestCase):
                             'value': 200,
                         },
                     ],
-                    2: [
+                    self.service_environments[1].id: [
                         {
                             'pricing_object_id': 3,
                             'type_id': self.service_usage_types[0].id,
@@ -86,7 +85,7 @@ class TestPricingServiceFixedPricePluginPlugin(TestCase):
                     ]
                 }
             return {
-                1: [
+                self.service_environments[0].id: [
                     {
                         'pricing_object_id': 1,
                         'type_id': self.service_usage_types[1].id,
@@ -94,7 +93,7 @@ class TestPricingServiceFixedPricePluginPlugin(TestCase):
                         'value': 300,
                     },
                 ],
-                2: [
+                self.service_environments[1].id: [
                     {
                         'pricing_object_id': 3,
                         'type_id': self.service_usage_types[1].id,
@@ -111,7 +110,7 @@ class TestPricingServiceFixedPricePluginPlugin(TestCase):
             service_environments=self.service_environments,
         )
         self.assertEquals(costs, {
-            1: [
+            self.service_environments[0].id: [
                 {
                     'type_id': self.pricing_service.id,
                     'pricing_object_id': 1,
@@ -145,7 +144,7 @@ class TestPricingServiceFixedPricePluginPlugin(TestCase):
                     ]
                 }
             ],
-            2: [
+            self.service_environments[1].id: [
                 {
                     'type_id': self.pricing_service.id,
                     'pricing_object_id': 3,

--- a/src/ralph_scrooge/tests/plugins/cost/test_collector.py
+++ b/src/ralph_scrooge/tests/plugins/cost/test_collector.py
@@ -78,7 +78,8 @@ class TestCollector(TestCase):
             self.end,
             True,
             False,
-            a=1
+            a=1,
+            service_environments=self.service_environments,
         ):
             pass
         calls = []


### PR DESCRIPTION
* added cache on all costs calculations - from now costs for single type is only calculated once (for all services and environments), result of it is cached to the end of worker job and if another plugin is interested in costs for particular service-environments, result for all is taken from cache and is filtered by pointed service-environments
* changed order of plugins to first calculate all basic types and at the end calculate pricing services