### PR TITLE
Update and rename openstack_ceilometer.py to openstack_mysql_ceilometer....

### DIFF
--- a/src/ralph_scrooge/plugins/collect/openstack_mysql_ceilometer.py
+++ b/src/ralph_scrooge/plugins/collect/openstack_mysql_ceilometer.py
@@ -129,7 +129,7 @@ def clear_ceilometer_stats(date):
 
 
 @plugin.register(chain='scrooge', requires=['service', 'tenant'])
-def openstack_ceilometer(today, **kwargs):
+def openstack_mysql_ceilometer(today, **kwargs):
     """
     Pricing plugin for openstack ceilometer.
     """


### PR DESCRIPTION
Due to creation another openstack plugin supporting MongoDB my proposition is to convert existing openstack_ceilometer.py plugin file to openstack_mysql_ceilometer.py. This, in turn, forces other changes in the whole system (settings etc)