### PR TITLE
fixed team division (%) template

### DIFF
--- a/src/ralph_scrooge/media/scrooge/partials/taballocationclientdivision.html
+++ b/src/ralph_scrooge/media/scrooge/partials/taballocationclientdivision.html
@@ -8,7 +8,7 @@
     </tr>
   </thead>
   <tbody>
-    <tr ng-repeat="row in stats.currentTabs.serviceDivision.rows">
+    <tr ng-repeat="row in stats.currentTabs[stats.currentTab].rows">
       <td ng-class="row.errors.service ? 'tab-error' : ''">
         <select ng-model="row.service" class="form-control" ng-options="service.id as service.name for service in stats.leftMenus.services">
         </select>
@@ -25,25 +25,25 @@
         <div>{{row.errors.value}}</div>
       </td>
       <td class="action-col">
-        <button ng-click="removeRow($index, stats.currentTabs.serviceDivision.rows)" type="button" class="btn btn-danger">-</button>
+        <button ng-click="removeRow($index, stats.currentTabs[stats.currentTab].rows)" type="button" class="btn btn-danger">-</button>
       </td>
     </tr>
     <tr class="additional-row-header">
       <td></td>
       <td></td>
-      <td ng-class="getTotal('serviceDivision')==100 ? 'green' : 'red'" class="col-xs-1 total">
-        {{getTotal('serviceDivision') | number:2}}
+      <td ng-class="getTotal(stats.currentTab)==100 ? 'green' : 'red'" class="col-xs-1 total">
+        {{getTotal(stats.currentTab) | number:2}}
         <div>%</div>
       </td>
       <td class="col-xs-1 action-col">
-        <button ng-click="addRow(stats.currentTabs.serviceDivision.rows)" type="button" class="btn btn-success">+</button>
+        <button ng-click="addRow(stats.currentTabs[stats.currentTab].rows)" type="button" class="btn btn-success">+</button>
       </td>
     </tr>
     <tr>
       <td></td>
       <td></td>
       <td></td>
-      <td class="action-col"><button ng-click="stats.saveAllocation('serviceDivision')" class="btn btn-success allocation-save">Save</button></td>
+      <td class="action-col"><button ng-click="stats.saveAllocation(stats.currentTab)" class="btn btn-success allocation-save">Save</button></td>
     </tr>
   </tbody>
 </table>

--- a/src/ralph_scrooge/rest/allocationclient.py
+++ b/src/ralph_scrooge/rest/allocationclient.py
@@ -188,7 +188,7 @@ class AllocationClientService(APIView):
             response.update({
                 "serviceDivision": {
                     "name": "Service Division",
-                    "template": "tabservicedivision.html",
+                    "template": "taballocationclientdivision.html",
                     "rows": self._get_service_divison(
                         service,
                         year,
@@ -291,7 +291,7 @@ class AllocationClientPerTeam(APIView):
         return Response({
             "teamDivision": {
                 "name": "Team Division",
-                "template": "tabteamcosts.html",
+                "template": "taballocationclientdivision.html",
                 "rows": self._get_team_divison(team, first_day, last_day),
             }
         })

--- a/src/ralph_scrooge/tests/rest/test_allocationclient.py
+++ b/src/ralph_scrooge/tests/rest/test_allocationclient.py
@@ -104,7 +104,7 @@ class TestAllocationClient(TestCase):
             {
                 "rows": [],
                 "name": "Service Division",
-                "template": "tabservicedivision.html",
+                "template": "taballocationclientdivision.html",
             }
         )
         # check if get request does not create new usage type
@@ -136,7 +136,7 @@ class TestAllocationClient(TestCase):
                     "service": self.service_environment_2.service.id
                 }],
                 "name": "Service Division",
-                "template": "tabservicedivision.html",
+                "template": "taballocationclientdivision.html",
             }
         )
 
@@ -158,7 +158,7 @@ class TestAllocationClient(TestCase):
             {
                 "rows": [],
                 "name": "Service Division",
-                "template": "tabservicedivision.html",
+                "template": "taballocationclientdivision.html",
             }
         )
         # check if get request does not create new usage type
@@ -204,7 +204,7 @@ class TestAllocationClient(TestCase):
                     "service": service_environment_1.service.id
                 }],
                 "name": "Service Division",
-                "template": "tabservicedivision.html",
+                "template": "taballocationclientdivision.html",
             }
         )
 
@@ -251,7 +251,7 @@ class TestAllocationClient(TestCase):
                     "service": service_environment_1.service.id
                 }],
                 "name": "Service Division",
-                "template": "tabservicedivision.html",
+                "template": "taballocationclientdivision.html",
             }
         )
         # check if this request created new usage type and created
@@ -383,7 +383,7 @@ class TestAllocationClient(TestCase):
             {
                 "rows": [],
                 "name": "Team Division",
-                "template": "tabteamcosts.html",
+                "template": "taballocationclientdivision.html",
             }
         )
 
@@ -421,7 +421,7 @@ class TestAllocationClient(TestCase):
                     'value': float(team_percent_2.percent),
                 }],
                 "name": "Team Division",
-                "template": "tabteamcosts.html",
+                "template": "taballocationclientdivision.html",
             }
         )
 
@@ -467,6 +467,6 @@ class TestAllocationClient(TestCase):
                     )
                 }],
                 "name": "Team Division",
-                "template": "tabteamcosts.html",
+                "template": "taballocationclientdivision.html",
             }
         )


### PR DESCRIPTION
previously in team division tab there was wrong template (teamcosts). From now team division and service division templates are merged into single, taballocationclientdivision template.