### PR TITLE
Fix: Printing correct decimal places in base_plugin_report.py and report_services_usages.py

### DIFF
--- a/src/ralph_scrooge/report/base_plugin_report.py
+++ b/src/ralph_scrooge/report/base_plugin_report.py
@@ -227,6 +227,9 @@ class BasePluginReport(BaseReport):
 
         if field_rules.get('rounding') is not None:
             field_content = round(field_content, field_rules['rounding'])
+            field_content = '{:.{prec}f}'.format(
+                field_content, prec=field_rules['rounding']
+            )
 
         if 'currency' in field_rules and field_rules['currency']:
             field_content = '{0:.2f}'.format(field_content)

--- a/src/ralph_scrooge/report/report_services_usages.py
+++ b/src/ralph_scrooge/report/report_services_usages.py
@@ -38,6 +38,7 @@ class ServicesUsagesReport(BasePluginReport):
             value = value / float(10 ** usage_type.divide_by)
 
         value = round(value, usage_type.rounding)
+        value = '{:.{prec}f}'.format(value, prec=usage_type.rounding)
         return value
 
     @classmethod


### PR DESCRIPTION
Printed values in base_plugin_report.py and report_services_usages.py are properly formatted using correct number of decimal places set in admin panel