### PR TITLE
Fixed pricing service costs distribution when pricing service has any services

### DIFF
--- a/src/ralph_scrooge/plugins/cost/base.py
+++ b/src/ralph_scrooge/plugins/cost/base.py
@@ -57,7 +57,7 @@ class BaseCostPlugin(BasePlugin):
         """
         costs = self._costs(*args, **kwargs)
         # filter by service environments if specified
-        if service_environments:
+        if service_environments is not None:
             se_ids = set([se.id for se in service_environments])
             costs = {k: v for (k, v) in costs.iteritems() if k in se_ids}
         return costs


### PR DESCRIPTION
When pricing service doesn't have any services, the cost was taken from all available services (empty list in if condition). Now if condition checks explicitly if `service_environments` is `None`.
