### PR TITLE
Convert return usage values from Mongo + add simple usages do Default WH when error

### DIFF
--- a/src/ralph_scrooge/api.py
+++ b/src/ralph_scrooge/api.py
@@ -313,7 +313,7 @@ class PricingServiceUsageResource(Resource):
         elif pricing_service_usages.pricing_service:
             ps_params['name'] = pricing_service_usages.pricing_service
         try:
-            PricingService.objects.get(**ps_params)
+            PricingService.objects_admin.get(**ps_params)
         except PricingService.DoesNotExist:
             raise ImmediateHttpResponse(response=http.HttpBadRequest(
                 "Invalid pricing service name ({}) or id ({})".format(
@@ -360,7 +360,7 @@ class PricingServiceUsageResource(Resource):
                     try:
                         usage_type = usage_types.get(
                             usage.symbol,
-                            UsageType.objects.get(symbol=usage.symbol)
+                            UsageType.objects_admin.get(symbol=usage.symbol)
                         )
                         daily_pricing_object = (
                             pricing_object.get_daily_pricing_object(
@@ -464,7 +464,7 @@ class PricingServiceUsageResource(Resource):
         Returns usages of pricing service (on date) for GET API
         """
         try:
-            pricing_service = PricingService.objects.get(
+            pricing_service = PricingService.objects_admin.get(
                 id=pricing_service_id,
             )
         except PricingService.DoesNotExist:

--- a/src/ralph_scrooge/management/commands/scrooge_tenants_instances.py
+++ b/src/ralph_scrooge/management/commands/scrooge_tenants_instances.py
@@ -117,7 +117,7 @@ class Command(ScroogeBaseCommand):
         """
         Return usage type and it's prices between start and end.
         """
-        usage_type = UsageType.objects.get(pk=type_id)
+        usage_type = UsageType.objects_admin.get(pk=type_id)
         prices = []
         for price in usage_type.usageprice_set.filter(
             start__lte=end,

--- a/src/ralph_scrooge/plugins/collect/_openstack_base.py
+++ b/src/ralph_scrooge/plugins/collect/_openstack_base.py
@@ -206,6 +206,7 @@ class OpenStackBasePlugin(object):
                 logger.error('Invalid warehouse: {}'.format(
                     site['WAREHOUSE']
                 ))
+                # default warehouse from fixtures
                 warehouse = Warehouse.objects.get(pk=1)
             usages = self.get_usages(today, site['CONNECTION'])
             site_new, site_total = self.save_usages(

--- a/src/ralph_scrooge/plugins/collect/_openstack_base.py
+++ b/src/ralph_scrooge/plugins/collect/_openstack_base.py
@@ -81,7 +81,7 @@ class OpenStackBasePlugin(object):
         else:
             usage_name = self.metric_tmpl.format(metric_name)
         usage_symbol = usage_name.lower().replace(':', '.').replace(' ', '_')
-        return UsageType.objects.get_or_create(
+        return UsageType.objects_admin.get_or_create(
             symbol=usage_symbol,
             defaults=dict(
                 name=usage_name,
@@ -206,7 +206,7 @@ class OpenStackBasePlugin(object):
                 logger.error('Invalid warehouse: {}'.format(
                     site['WAREHOUSE']
                 ))
-                continue
+                warehouse = Warehouse.objects.get(pk=1)
             usages = self.get_usages(today, site['CONNECTION'])
             site_new, site_total = self.save_usages(
                 usages,

--- a/src/ralph_scrooge/plugins/collect/asset.py
+++ b/src/ralph_scrooge/plugins/collect/asset.py
@@ -244,7 +244,7 @@ def get_usage(symbol, name, by_warehouse, by_cost, average, type):
     :returns object: Django orm UsageType object
     :rtype object:
     """
-    usage_type, created = UsageType.objects.get_or_create(
+    usage_type, created = UsageType.objects_admin.get_or_create(
         symbol=symbol,
         defaults=dict(
             name=name,

--- a/src/ralph_scrooge/plugins/collect/blade_server.py
+++ b/src/ralph_scrooge/plugins/collect/blade_server.py
@@ -68,7 +68,7 @@ def get_usage_type():
     """
     Returns Blade Server usage type
     """
-    return UsageType.objects.get_or_create(
+    return UsageType.objects_admin.get_or_create(
         symbol='blade_server',
         defaults=dict(
             name='Blade server',

--- a/src/ralph_scrooge/plugins/collect/netflow.py
+++ b/src/ralph_scrooge/plugins/collect/netflow.py
@@ -274,7 +274,7 @@ def get_usage_type():
     :returns object: Network Bytes usage type
     :rtype object:
     """
-    usage_type, created = UsageType.objects.get_or_create(
+    usage_type, created = UsageType.objects_admin.get_or_create(
         name="Network Bytes",
         symbol='network_bytes',
     )

--- a/src/ralph_scrooge/plugins/collect/openstack_simple_usage.py
+++ b/src/ralph_scrooge/plugins/collect/openstack_simple_usage.py
@@ -58,7 +58,7 @@ def clear_openstack_simple_usages(date):
 def get_usage_types():
     usages = {}
     for usage_symbol, usage_name in USAGES:
-        usage_type, created = UsageType.objects.get_or_create(
+        usage_type, created = UsageType.objects_admin.get_or_create(
             symbol=USAGE_SYMBOL_TMPL.format(usage_symbol),
             defaults=dict(
                 name=usage_name,

--- a/src/ralph_scrooge/plugins/collect/san.py
+++ b/src/ralph_scrooge/plugins/collect/san.py
@@ -68,7 +68,7 @@ def get_usage_type():
     """
     Returns SAN usage type
     """
-    return UsageType.objects.get_or_create(
+    return UsageType.objects_admin.get_or_create(
         symbol='san',
         defaults=dict(
             name='SAN',

--- a/src/ralph_scrooge/plugins/collect/share.py
+++ b/src/ralph_scrooge/plugins/collect/share.py
@@ -71,7 +71,7 @@ def get_usage(usage_name):
     """
     Returns usage type for specific shares
     """
-    usage_type, created = UsageType.objects.get_or_create(
+    usage_type, created = UsageType.objects_admin.get_or_create(
         symbol=usage_name.replace(' ', '_').lower(),
         defaults=dict(
             name=usage_name,

--- a/src/ralph_scrooge/plugins/collect/virtual.py
+++ b/src/ralph_scrooge/plugins/collect/virtual.py
@@ -180,7 +180,7 @@ def get_or_create_usages(usage_names):
     :returns dict: Dict with usage types
     :rtype dict:
     """
-    cpu_usage, created = UsageType.objects.get_or_create(
+    cpu_usage, created = UsageType.objects_admin.get_or_create(
         symbol=usage_names['virtual_cores'].replace(' ', '_').lower(),
         defaults=dict(
             name=usage_names['virtual_cores'],
@@ -189,7 +189,7 @@ def get_or_create_usages(usage_names):
     )
     cpu_usage.save()
 
-    memory_usage, created = UsageType.objects.get_or_create(
+    memory_usage, created = UsageType.objects_admin.get_or_create(
         symbol=usage_names['virtual_memory'].replace(' ', '_').lower(),
         defaults=dict(
             name=usage_names['virtual_memory'],
@@ -198,7 +198,7 @@ def get_or_create_usages(usage_names):
     )
     memory_usage.save()
 
-    disk_usage, created = UsageType.objects.get_or_create(
+    disk_usage, created = UsageType.objects_admin.get_or_create(
         symbol=usage_names['virtual_disk'].replace(' ', '_').lower(),
         defaults=dict(
             name=usage_names['virtual_disk'],

--- a/src/ralph_scrooge/rest/allocationadmin.py
+++ b/src/ralph_scrooge/rest/allocationadmin.py
@@ -209,7 +209,7 @@ class AllocationAdminContent(APIView):
     def _save_base_usages(self, start, end, post_data):
         for row in post_data['rows']:
             try:
-                usage_type = UsageType.objects.get(id=row['type']['id'])
+                usage_type = UsageType.objects_admin.get(id=row['type']['id'])
             except UsageType.DoesNotExist:
                 raise NoUsageTypeError(
                     'No usage type with id {0}'.format(row['type']['id'])
@@ -233,7 +233,7 @@ class AllocationAdminContent(APIView):
     def _save_extra_costs(self, start, end, post_data):
         for row in post_data['rows']:
             try:
-                extra_cost_type = ExtraCostType.objects.get(
+                extra_cost_type = ExtraCostType.objects_admin.get(
                     id=row['extra_cost_type']['id'],
                 )
             except ExtraCostType.DoesNotExist:
@@ -288,9 +288,10 @@ class AllocationAdminContent(APIView):
     def _save_dynamic_extra_costs(self, start, end, post_data):
         for row in post_data['rows']:
             try:
-                dynamic_extra_cost_type = DynamicExtraCostType.objects.get(
-                    id=row['dynamic_extra_cost_type']['id'],
-                )
+                dynamic_extra_cost_type =\
+                    DynamicExtraCostType.objects_admin.get(
+                        id=row['dynamic_extra_cost_type']['id'],
+                    )
             except DynamicExtraCostType.DoesNotExist:
                 raise NoDynamicExtraCostTypeError(
                     'No dynamic extra cost type with id {0}'.format(

--- a/src/ralph_scrooge/rest/allocationclient.py
+++ b/src/ralph_scrooge/rest/allocationclient.py
@@ -48,7 +48,9 @@ class AllocationClientService(APIView):
     ):
         service = Service.objects.get(id=service)
         try:
-            pricing_service = PricingService.objects.get(services=service)
+            pricing_service = PricingService.objects.get(
+                services=service
+            )
         except PricingService.DoesNotExist:
             if not create_if_not_exist:
                 return None
@@ -147,7 +149,7 @@ class AllocationClientService(APIView):
                 environment__id=env,
 
             ),
-            extra_cost_type=1  # ExtraCostType.objects.get(name="other")
+            extra_cost_type=1  # ExtraCostType.objects_admin.get(name="other")
         )
         rows = []
         for extra_cost in extra_costs:

--- a/src/ralph_scrooge/tests/plugins/collect/test_asset.py
+++ b/src/ralph_scrooge/tests/plugins/collect/test_asset.py
@@ -66,7 +66,7 @@ class TestAssetPlugin(TestCase):
             True,
             'SU',
         )
-        self.assertEqual(usage_type, UsageType.objects.get())
+        self.assertEqual(usage_type, UsageType.objects_admin.get())
         self.assertEqual(usage_type.symbol, 'test_symbol')
         self.assertEqual(usage_type.name, 'test_name')
         self.assertEqual(usage_type.by_warehouse, True)

--- a/src/ralph_scrooge/tests/plugins/collect/test_netflow.py
+++ b/src/ralph_scrooge/tests/plugins/collect/test_netflow.py
@@ -237,7 +237,10 @@ class TestNetwork(TestCase):
         )
 
     def test_get_usages_type(self):
-        self.assertEqual(netflow.get_usage_type(), UsageType.objects.get())
+        self.assertEqual(
+            netflow.get_usage_type(),
+            UsageType.objects_admin.get()
+        )
 
     @override_settings(UNKNOWN_SERVICES={'netflow': 1})
     def test_update(self):

--- a/src/ralph_scrooge/tests/plugins/cost/test_support.py
+++ b/src/ralph_scrooge/tests/plugins/cost/test_support.py
@@ -20,7 +20,7 @@ class TestSupportPlugin(TestCase):
         self.start = date(2013, 10, 1)
         self.end = date(2013, 10, 30)
 
-        self.support_type = models.ExtraCostType.objects.get(pk=2)
+        self.support_type = models.ExtraCostType.objects_admin.get(pk=2)
         self.pricing_objects = PricingObjectFactory.create_batch(5)
         self.service_environments = [
             po.service_environment for po in self.pricing_objects

--- a/src/ralph_scrooge/tests/rest/test_allocationclient.py
+++ b/src/ralph_scrooge/tests/rest/test_allocationclient.py
@@ -75,7 +75,7 @@ class TestAllocationClient(TestCase):
             start=self.date,
             end=self.date + datetime.timedelta(days=30),
             service_environment=service_environment,
-            extra_cost_type=models.ExtraCostType.objects.get(id=1),
+            extra_cost_type=models.ExtraCostType.objects_admin.get(id=1),
         )
 
     def _create_team_division(self, service_environment, team):

--- a/src/ralph_scrooge/utils/demo.py
+++ b/src/ralph_scrooge/utils/demo.py
@@ -86,8 +86,8 @@ class ExtraCostTypeDemo(DemoData):
 
     def generate_data(self, data):
         return {
-            'support': ExtraCostType.objects.get(name='Support'),
-            'other': ExtraCostType.objects.get(name='Other'),
+            'support': ExtraCostType.objects_admin.get(name='Support'),
+            'other': ExtraCostType.objects_admin.get(name='Other'),
             'maintenance': ExtraCostTypeFactory(name='Maintenance'),
         }
 
@@ -119,7 +119,7 @@ class DynamicExtraCostDemo(DemoData):
         insurance = DynamicExtraCostTypeFactory(name='Insurance')
         DynamicExtraCostDivision.objects.create(
             dynamic_extra_cost_type=insurance,
-            usage_type=UsageType.objects.get(name='Depreciation'),
+            usage_type=UsageType.objects_admin.get(name='Depreciation'),
             percent=100,
         )
         DynamicExtraCost.objects.create(


### PR DESCRIPTION
Convert return usage values to conform to new files layout and classes division + removes the error when Warehouse does not exists when pulling Openstack simple usages (usages are added to Default WH)
