### PR TITLE
Dedicated queue and cache for main costs recalculation process

### DIFF
--- a/src/ralph_scrooge/utils/common.py
+++ b/src/ralph_scrooge/utils/common.py
@@ -52,15 +52,17 @@ class HashableDict(dict):
         return self.__key() == other.__key()
 
 
-def get_cache_name(name):
-    if name in settings.CACHES:
-        return name
+def get_cache_name(*names):
+    for name in names:
+        if name in settings.CACHES:
+            return name
     return 'default'
 
 
-def get_queue_name(name):
-    if name in settings.RQ_QUEUES:
-        return name
+def get_queue_name(*names):
+    for name in names:
+        if name in settings.RQ_QUEUES:
+            return name
     return 'default'
 
 

--- a/src/ralph_scrooge/views/monthly_costs.py
+++ b/src/ralph_scrooge/views/monthly_costs.py
@@ -27,6 +27,7 @@ from ralph_scrooge.models import CostDateStatus
 logger = logging.getLogger(__name__)
 
 
+# TODO: rename this view to sth more general (ex. CostsRecalculation)
 class MonthlyCosts(WorkerJob, Base):
     template_name = 'ralph_scrooge/monthly_costs.html'
     Form = MonthlyCostsForm
@@ -37,8 +38,8 @@ class MonthlyCosts(WorkerJob, Base):
     )
     initial = None
 
-    queue_name = get_queue_name('scrooge_costs')
-    cache_name = get_cache_name('scrooge_costs')
+    queue_name = get_queue_name('scrooge_costs_master', 'scrooge_costs')
+    cache_name = get_cache_name('scrooge_costs_master', 'scrooge_costs')
     cache_section = 'scrooge_costs'
     cache_timeout = 60 * 60 * 24  # 24 hours (max time for plugin to run)
     cache_final_result_timeout = 60 * 60 * 2  # 2 hours


### PR DESCRIPTION
- added (looking for) dedicated queue and cache (scrooge_costs_master) in main costs recalculation process
- get_queue_name and get_cache_name now accept variable number of params (*names) - first queue/cache found in settings will be returned, otherwise default
