### PR TITLE
Changed way of bulk creating DailyCosts to namedtuple instead of Django objects

### DIFF
--- a/src/ralph_scrooge/models/_tree.py
+++ b/src/ralph_scrooge/models/_tree.py
@@ -5,54 +5,68 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from collections import namedtuple
+
 from django.db import models as db
+from django.db.models.base import ModelBase
 
 
-class PathFieldNotConfiguredError(Exception):
-    pass
+class NamedtupleDjangoModelMeta(ModelBase):
+    """
+    Add namedtuple mapping for Django ORM model.
+    """
+    def __new__(cls, name, bases, attrs):
+        new_class = super(NamedtupleDjangoModelMeta, cls).__new__(
+            cls, name, bases, attrs
+        )
+        # create namedtuple with fields from model
+        # notice that ForeignKeys fields are inserted with '_id' suffix
+        # (ex. user -> user_id)
+        ntpl = namedtuple(
+            name,
+            ['pk'] + [f.attname for f in new_class._meta.fields]
+        )
+        # set defaults to None - this will allow to specify subset of fields
+        # when creating new object
+        ntpl.__new__.__defaults__ = (None,) * (len(ntpl._fields))
+        # create set of fields to speed-up fields searching
+        ntpl._fields_set = set(ntpl._fields)
+        # mapping from foreign key name to it's database field name
+        # (ex. user -> user_id)
+        ntpl._foreign_key_mapping = {
+            f.name: f.attname for f in new_class._meta.fields if (
+                isinstance(f, db.ForeignKey)
+            )
+        }
+        new_class.namedtuple = ntpl
+        return new_class
 
 
 class MultiPathNode(db.Model):
+    __metaclass__ = NamedtupleDjangoModelMeta
     _path_link = '/'
     _path_field = None
 
     path = db.CharField(max_length=255,)
     depth = db.PositiveIntegerField(default=0,)
-    parent = None
+    parent = None  # to be replaced in inheriting class
 
     class Meta:
         abstract = True
         app_label = 'ralph_scrooge'
 
-    def _create_path(self, *args, **kwargs):
-        if not self._path_field:
-            raise PathFieldNotConfiguredError()
-        if self.parent is not None:
-            self.path = self._parse_path(self.parent.path)
-            self.depth = self.parent.depth + 1
-        else:
-            self.path = self._parse_path('')
-
-    def _parse_path(self, parent_path):
+    @classmethod
+    def _parse_path(cls, parent_path, data):
         """
         Returns path as join of parent path with value of current object path
         field value.
         """
-        path_field_value = getattr(self, self._path_field)
+        path_field_value = data.get(cls._path_field)
         l = []
         if parent_path:
             l.append(parent_path)
         l.append(path_field_value)
-        return self._path_link.join(map(str, l))
-
-    def add_child(self, **kwargs):
-        """
-        Adds single child to object (link self as parent).
-        """
-        newobj = self.__class__(**kwargs)
-        newobj.parent = self
-        newobj._create_path()
-        return newobj
+        return cls._path_link.join(map(str, l))
 
     @classmethod
     def build_tree(cls, *args, **kwargs):
@@ -61,37 +75,46 @@ class MultiPathNode(db.Model):
         return result
 
     @classmethod
-    def _are_params_valid(self, params):
+    def _are_params_valid(cls, params):
         return True
 
     @classmethod
     def _build_tree(cls, tree, parent=None, **global_params):
         """
-        Build MultiPath tree Nodes according to tree list
+        Build objects ready to save to DB using bulk_create according to tree
+        list.
 
         :param list tree: list of dicts. dict values will be passed as kwargs
             to new objects. Dict '_children' list value will be used to create
-            node children.
+            children nodes.
+
+        :rtype: list of namedtuples
         """
         assert isinstance(tree, (list, tuple))
         result = []
         for child in tree:
             assert isinstance(child, dict)
-            params = dict(
-                [(k, v) for k, v in child.items() if (
-                    not k.startswith('_') and
-                    k not in ('percent', )
-                )]
-            )
+            params = {}
+            for k, v in child.items():
+                # check if key is in foreignkey mapping - if yes, it's Foreign
+                # Key - should take it mapped key as key (ex. user -> user_id)
+                # and pk as value (ex. user -> user.id)
+                if k in cls.namedtuple._foreign_key_mapping:
+                    k = cls.namedtuple._foreign_key_mapping[k]
+                    if v:
+                        v = v.pk
+                # save only params which are present in model
+                if k in cls.namedtuple._fields_set:
+                    params[k] = v
             params.update(global_params)
             if cls._are_params_valid(params):
-                if parent is None:
-                    newobj = cls(**params)
-                    newobj._create_path()
-                    result.append(newobj)
-                else:
-                    newobj = parent.add_child(**params)
-                    result.append(newobj)
+                params['depth'] = parent.depth + 1 if parent else 0
+                params['path'] = cls._parse_path(
+                    parent.path if parent else '',
+                    params
+                )
+                newobj = cls.namedtuple(**params)
+                result.append(newobj)
                 result.extend(cls._build_tree(
                     child.get('_children', []), newobj, **global_params
                 ))

--- a/src/ralph_scrooge/models/cost.py
+++ b/src/ralph_scrooge/models/cost.py
@@ -90,7 +90,7 @@ class DailyCost(MultiPathNode):
     @classmethod
     def _are_params_valid(self, params):
         if 'cost' in params:
-            return params['cost'] > 0
+            return params['cost'] != 0
         return True
 
 


### PR DESCRIPTION
- reduced memory usage while bulk creating (and saving) DailyCosts - use namedtuples insted of plain Django objects
- added additional unit tests

Connected to #443 

I've conducted some tests for memory usage and time consumption when creating `DailyCost` (or `DailyCost`-like) objects using `DailyCost` model, `AttributeDict` (dict which behave like object - you could set/get item like regular object attribute) and `namedtuple`.

I've used these 2 data structures, because django's `bulk_create` actually will work with anything supporting `getattr` (by name): https://github.com/django/django/blob/1.4.20/django/db/models/sql/subqueries.py#L156 (this is called under-the-hood when calling `bulk_create`)

`Namedtuple`s will be used in future implementation of this PR.

Next steps:
- performance tweaks of `_build_namedtuples`
- clean-up old methods (`_build_tree` and related)
- additional unit tests
- (maybe) use namedtuples in whole cost collector instead of simple dict (then there will be no need to create namedtuples in next step)

(Tests results from 1 run - just to demonstrate the order of magnitude)

Memory usage results:

| N | Django object | AttributeDict | namedtuple |
| :-: | :-: | :-: | :-: |
| 5000 | 27.7 MiB | 1.0 MiB | 0.3 MiB |
| 25000 | 145 MiB | 24.7 MiB | 18.2 MiB |
| 125000 | 739 MiB | 156 MiB | 103 MiB |

Performance results:

| N | Django object | AttributeDict | namedtuple |
| :-: | :-: | :-: | :-: |
| 5000 | 11.5s | 2.9s | 2.8s |
| 25000 | 63.9s | 14.8s | 14.6s |
| 125000 | 323s | 84s | 71s |
