### PR TITLE
added volumes to openstack report

### DIFF
--- a/src/ralph_scrooge/models/_tree.py
+++ b/src/ralph_scrooge/models/_tree.py
@@ -113,6 +113,8 @@ class MultiPathNode(db.Model):
                     parent.path if parent else '',
                     params
                 )
+                if params.get('value') is None:
+                    params['value'] = 0
                 newobj = cls.namedtuple(**params)
                 result.append(newobj)
                 result.extend(cls._build_tree(

--- a/src/ralph_scrooge/tests/management/commands/test_scrooge_tenants_instances.py
+++ b/src/ralph_scrooge/tests/management/commands/test_scrooge_tenants_instances.py
@@ -135,9 +135,9 @@ class TestScroogeTenantsInstances(TestCase):
             calls.append(mock.call(
                 day,
                 True,
-                plugins[:2],
+                plugins=plugins[:2],
             ))
-        process_mock.assert_has_calls(calls)
+        process_mock.assert_has_calls(calls, any_order=True)
 
     def _set_usage_prices(self):
         self.usage_price1 = UsagePriceFactory(

--- a/src/ralph_scrooge/tests/plugins/collect/test_openstack_cinder_volumes_mysql.py
+++ b/src/ralph_scrooge/tests/plugins/collect/test_openstack_cinder_volumes_mysql.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import datetime
+import mock
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from ralph_scrooge.plugins.collect.openstack_cinder_volumes_mysql import (
+    CinderVolumesPlugin
+)
+
+
+class TestOpenStackCinderVolumesMysqlUsage(TestCase):
+    def setUp(self):
+        self.today = datetime.date(2014, 7, 1)
+        self.plugin = CinderVolumesPlugin()
+
+    def _mock_sql_query(self, create_engine_mock, return_value):
+        def execute_mock(sql):
+            return return_value
+
+        connection_mock = mock.MagicMock()
+        connection_mock.execute.side_effect = execute_mock
+
+        engine_mock = mock.MagicMock()
+        engine_mock.connect.return_value = connection_mock
+
+        create_engine_mock.return_value = engine_mock
+
+    @mock.patch('ralph_scrooge.plugins.collect._openstack_base.create_engine')
+    def test_get_usages_volume_type_present(self, create_engine_mock):
+        self._mock_sql_query(
+            create_engine_mock,
+            [('111', '/vol/1', '321', 10, 10, '123@SSD-2', 'SSD-1')]
+        )
+        result = [x for x in self.plugin.get_usages(self.today, 'mysql')]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], ('321', 10, 'SSD-1', '111: /vol/1'))
+
+    @mock.patch('ralph_scrooge.plugins.collect._openstack_base.create_engine')
+    def test_get_usages_volume_type_not_present(self, create_engine_mock):
+        self._mock_sql_query(
+            create_engine_mock,
+            [('111', '/vol/1', '321', 10, 10, '123@SSD-2', None)]
+        )
+        result = [x for x in self.plugin.get_usages(self.today, 'mysql')]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], ('321', 10, 'SSD-2', '111: /vol/1'))
+
+    @mock.patch('ralph_scrooge.plugins.collect._openstack_base.create_engine')
+    def test_get_usages_volume_type_and_host_null(self, create_engine_mock):
+        self._mock_sql_query(
+            create_engine_mock,
+            [('111', '/vol/1', '321', 10, 10, None, None)]
+        )
+        result = [x for x in self.plugin.get_usages(self.today, 'mysql')]
+        self.assertEqual(len(result), 0)
+
+    @mock.patch('ralph_scrooge.plugins.collect._openstack_base.create_engine')
+    @override_settings(OPENSTACK_CINDER_VOLUMES_DONT_CHARGE_FOR_SIZE=['SSD-1'])
+    def test_get_usages_volume_type_dont_charge_for_size(
+        self, create_engine_mock
+    ):
+        self._mock_sql_query(
+            create_engine_mock,
+            [('111', '/vol/1', '321', 10, 10, '123@SSD-2', 'SSD-1')]
+        )
+        result = [x for x in self.plugin.get_usages(self.today, 'mysql')]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], ('321', 1, 'SSD-1', '111: /vol/1'))


### PR DESCRIPTION
- fixed cost saving without value
- added volumes to openstack report
- save 24 instead of 1 in cinder volume when not charging for size
