### PR TITLE
Fix allocation admin tab

### DIFF
--- a/src/ralph_scrooge/media/scrooge/app/allocationadmin/controller.js
+++ b/src/ralph_scrooge/media/scrooge/app/allocationadmin/controller.js
@@ -8,11 +8,12 @@ scrooge.controller('allocationAdminCtrl', ['$scope', '$routeParams', '$http', 's
     }
     stats.breadcrumbs = ['tab'];
     if ($scope.stats.currentSubMenu === false) {
-        $scope.stats.currentSubMenu = 'Allocations Admin';
+        $scope.stats.currentSubMenu = 'Allocations admin';
     }
     stats.refreshCurrentSubpage = function () {
         stats.getAllocationAdminData();
     };
+
     $scope.stats.menuStats.subpage.change = 'allocationadmin';
     $scope.stats.refreshData();
 
@@ -29,11 +30,9 @@ scrooge.controller('allocationAdminCtrl', ['$scope', '$routeParams', '$http', 's
         return total;
     };
     $scope.addRow = function (costList) {
-        costList.push({'service': false, 'env': false, 'cost': 0, 'forecast_cost': 0});
+        costList.push({'service': false, 'env': false, 'cost': 0, 'forecast_cost': 0, '_empty': true});
     };
     $scope.removeRow = function (index, currentList) {
-        if (currentList.length >= 2) {
-            currentList.splice(index, 1);
-        }
+        currentList.splice(index, 1);
     };
 }]);

--- a/src/ralph_scrooge/media/scrooge/app/allocationclient/controller.js
+++ b/src/ralph_scrooge/media/scrooge/app/allocationclient/controller.js
@@ -22,7 +22,7 @@ scrooge.controller('allocationClientCtrl', ['$scope', '$routeParams', '$http', '
      * @param {list} costList - List of dicts with row data.
      */
     $scope.addRow = function (costList) {
-        costList.push({'service': false, 'value': 0});
+        costList.push({'service': false, 'value': 0, '_empty': true});
     };
 
     /**
@@ -31,9 +31,7 @@ scrooge.controller('allocationClientCtrl', ['$scope', '$routeParams', '$http', '
      * @param {list} currentList - List of dicts with row data.
      */
     $scope.removeRow = function (index, currentList) {
-        if (currentList.length >= 2) {
-            currentList.splice(index, 1);
-        }
+        currentList.splice(index, 1);
     };
 
     /**

--- a/src/ralph_scrooge/media/scrooge/partials/taballocationclientdivision.html
+++ b/src/ralph_scrooge/media/scrooge/partials/taballocationclientdivision.html
@@ -10,13 +10,15 @@
   <tbody>
     <tr ng-repeat="row in stats.currentTabs[stats.currentTab].rows">
       <td ng-class="row.errors.service ? 'tab-error' : ''">
-        <select ng-model="row.service" class="form-control" ng-options="service.id as service.name for service in stats.leftMenus.services">
+        <select ng-if="row._empty === true" ng-model="row.service" class="form-control" ng-options="service.id as service.name for service in stats.leftMenus.services">
         </select>
+        <div ng-if="row._empty !== true">{{stats.getServiceName(row.service)}}</div>
         <div>{{row.errors.service}}</div>
       </td>
       <td ng-class="row.errors.env ? 'tab-error' : ''">
-        <select ng-model="row.env" class="form-control" ng-options="env.id as env.name for env in stats.getEnvs(row.service)">
+        <select ng-if="row._empty === true" ng-model="row.env" class="form-control" ng-options="env.id as env.name for env in stats.getEnvs(row.service)">
         </select>
+        <div ng-if="row._empty !== true">{{stats.getEnvName(row.env)}}</div>
         <div>{{row.errors.env}}</div>
       </td>
       <td class="value-col value-percent-col" ng-class="row.errors.value ? 'tab-error' : ''">

--- a/src/ralph_scrooge/media/scrooge/partials/tabextracostsadmin.html
+++ b/src/ralph_scrooge/media/scrooge/partials/tabextracostsadmin.html
@@ -15,12 +15,14 @@
     <tbody>
       <tr ng-repeat="row in extra_cost_type.extra_costs">
         <td ng-class="row.errors.service ? 'tab-error' : ''">
-          <select ng-model="row.service" class="form-control" ng-options="service.id as service.name for service in stats.leftMenus.services">
+          <div ng-if="row._empty !== true">{{stats.getServiceName(row.service)}}</div>
+          <select ng-if="row._empty === true" ng-model="row.service" class="form-control" ng-options="service.id as service.name for service in stats.leftMenus.services">
           </select>
           <div>{{row.errors.service}}</div>
         </td>
         <td ng-class="row.errors.env ? 'tab-error' : ''">
-          <select ng-model="row.env" class="form-control" ng-options="env.id as env.name for env in stats.getEnvs(row.service)">
+          <div ng-if="row._empty !== true">{{stats.getEnvName(row.env)}}</div>
+          <select ng-if="row._empty === true" ng-model="row.env" class="form-control" ng-options="env.id as env.name for env in stats.getEnvs(row.service)">
           </select>
           <div>{{row.errors.env}}</div>
         </td>

--- a/src/ralph_scrooge/rest/allocationadmin.py
+++ b/src/ralph_scrooge/rest/allocationadmin.py
@@ -69,8 +69,6 @@ class AllocationAdminContent(APIView):
                     'service': extra_cost.service_environment.service_id,
                     'env': extra_cost.service_environment.environment_id
                 })
-            if len(extra_costs) == 0:
-                extra_costs = [{}]
             rows.append({
                 'extra_cost_type': {
                     'id': extra_cost_type.id,
@@ -231,6 +229,7 @@ class AllocationAdminContent(APIView):
             usage_price.save()
 
     def _save_extra_costs(self, start, end, post_data):
+        saved_costs = []
         for row in post_data['rows']:
             try:
                 extra_cost_type = ExtraCostType.objects_admin.get(
@@ -284,6 +283,11 @@ class AllocationAdminContent(APIView):
                             cost=ec_row['cost'],
                             forecast_cost=ec_row['forecast_cost']
                         )
+                    saved_costs.append(extra_cost.id)
+        # delete extra costs that were missing in the form
+        ExtraCost.objects.filter(start=start, end=end).exclude(
+            pk__in=saved_costs
+        ).delete()
 
     def _save_dynamic_extra_costs(self, start, end, post_data):
         for row in post_data['rows']:


### PR DESCRIPTION
- don't render selects for each service-env in extra costs allocation admin tab - selects with service-env are rendered only for new rows - for existing rows text value is displayed
- fixed allocation admin reload (datepicker was not displayed before)
- fixed removing extra costs
