### PR TITLE
Allow to specify services sync scope

### DIFF
--- a/src/ralph_scrooge/plugins/collect/service.py
+++ b/src/ralph_scrooge/plugins/collect/service.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import logging
 
+from django.conf import settings
 from django.db.transaction import commit_on_success
 
 from ralph.util import plugin
@@ -93,7 +94,9 @@ def service(today, **kwargs):
     """
     new_services = total = 0
     default_profit_center = ProfitCenter.objects.get(pk=1)
-    for data in get_services():
+    for data in get_services(
+        settings.SYNC_SERVICES_ONLY_CALCULATED_IN_SCROOGE
+    ):
         if update_service(data, today, default_profit_center):
             new_services += 1
         total += 1

--- a/src/ralph_scrooge/settings.py
+++ b/src/ralph_scrooge/settings.py
@@ -46,6 +46,7 @@ COLLECT_PLUGINS = set([
     'virtual',
 ])
 
+SYNC_SERVICES_ONLY_CALCULATED_IN_SCROOGE = False
 UNKNOWN_SERVICES_ENVIRONMENTS = {
     'tenant': {},
     'netflow': (None, None),

--- a/src/ralph_scrooge/tests/plugins/collect/test_service.py
+++ b/src/ralph_scrooge/tests/plugins/collect/test_service.py
@@ -148,7 +148,7 @@ class TestServiceCollectPlugin(TestCase):
         def sample_update_service(data, date, default_profit_center):
             return data['ci_id'] % 2 == 0
 
-        def sample_get_services():
+        def sample_get_services(only_calculated_in_scrooge=False):
             for owner in SAMPLE_SERVICES:
                 yield owner
 


### PR DESCRIPTION
Set `SYNC_SERVICES_ONLY_CALCULATED_IN_SCROOGE` to `True` to fetch only services with 'Calculated in Scrooge' flag.
