### PR TITLE
Add Ralph3 plugins mapping (they replace some of Ralph2 plugins)

### DIFF
--- a/src/ralph_scrooge/management/commands/scrooge_sync.py
+++ b/src/ralph_scrooge/management/commands/scrooge_sync.py
@@ -89,9 +89,19 @@ def run_plugins(today, plugins, run_only=False):
                 try:
                     _run_plugin(name, today)
                     done.add(name)
+                    # TODO (mkurek): remove it after migration to Ralph3 is
+                    # completed
+                    # mark some Ralph2-related plugins as done to allow
+                    # dependent plugins to run properly (they will run only
+                    # if their precondition on other plugins is completed)
+                    done.update(
+                        settings.RALPH3_COLLECT_PLUGINS_MAPPING.get(name, [])
+                    )
                     yield name, True
                 except PluginError:
                     yield name, False
+            else:
+                logger.debug('{} not on plugin list. Skipping..'.format(name))
 
         # save not executed plugins
         for p in set(plugins) - tried:

--- a/src/ralph_scrooge/plugins/collect/ralph3_cloud_project.py
+++ b/src/ralph_scrooge/plugins/collect/ralph3_cloud_project.py
@@ -109,7 +109,7 @@ def get_cloud_provider_id(logger):
             return provider['id']
 
 
-@plugin.register(chain='scrooge', requires=['service'])
+@plugin.register(chain='scrooge', requires=['ralph3_service_environment'])
 def ralph3_cloud_project(today, **kwargs):
     new = total = 0
     try:

--- a/src/ralph_scrooge/plugins/collect/ralph3_profit_center.py
+++ b/src/ralph_scrooge/plugins/collect/ralph3_profit_center.py
@@ -42,7 +42,7 @@ def update_profit_center(pc, default_business_line):
     return created
 
 
-@plugin.register(chain='scrooge', requires=['business_segment'])
+@plugin.register(chain='scrooge', requires=['ralph3_business_segment'])
 def ralph3_profit_center(**kwargs):
     new_pc = total = 0
     default_business_line = BusinessLine.objects.get(pk=1)

--- a/src/ralph_scrooge/plugins/collect/ralph3_service_environment.py
+++ b/src/ralph_scrooge/plugins/collect/ralph3_service_environment.py
@@ -97,7 +97,7 @@ def update_environment(env_from_ralph):
     return created
 
 
-@plugin.register(chain='scrooge', requires=[])
+@plugin.register(chain='scrooge', requires=['ralph3_profit_center'])
 def ralph3_service_environment(**kwargs):
     new_services = total_services = 0
     new_envs = total_envs = 0

--- a/src/ralph_scrooge/settings.py
+++ b/src/ralph_scrooge/settings.py
@@ -50,6 +50,14 @@ COLLECT_PLUGINS = set([
     'vip',
     'virtual',
 ])
+RALPH3_COLLECT_PLUGINS_MAPPING = {
+    'ralph3_service_environment': ['service', 'environment'],
+    'ralph3_profit_center': ['profit_center'],
+    'ralph3_data_center': ['warehouse'],
+    'ralph3_business_segment': ['business_line'],
+    'ralph3_asset_model': ['asset_model'],
+    'ralph3_asset': ['asset'],
+}
 
 SYNC_SERVICES_ONLY_CALCULATED_IN_SCROOGE = False
 UNKNOWN_SERVICES_ENVIRONMENTS = {


### PR DESCRIPTION
Mark Ralph2-related plugins as done when processing their Ralph3-equivalent to enable processing of not-rewrited plugins (which depends on Ralph2-related plugins, like asset, openstack\* etc).
