### PR TITLE
[switch to R3] Add ralph3_vip plugin.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=[
         'ralph>=2.3.1',
         'ralph_assets>=2.5.1',
+        'pyhermes>=0.1.3',
         'pymongo>=2.7.2',
         'python-novaclient==2.17.0',
         'django-simple-history==1.6.3',

--- a/src/ralph_scrooge/management/commands/scrooge_ralph3_migrate_model.py
+++ b/src/ralph_scrooge/management/commands/scrooge_ralph3_migrate_model.py
@@ -22,7 +22,7 @@ from ralph_scrooge.models import (
     ProfitCenter,
     TenantInfo,
     Warehouse,
-    VirtualInfo
+    VirtualInfo,
     VIPInfo,
 )
 

--- a/src/ralph_scrooge/management/commands/scrooge_ralph3_migrate_model.py
+++ b/src/ralph_scrooge/management/commands/scrooge_ralph3_migrate_model.py
@@ -23,6 +23,7 @@ from ralph_scrooge.models import (
     TenantInfo,
     Warehouse,
     VirtualInfo
+    VIPInfo,
 )
 
 
@@ -37,6 +38,7 @@ MODEL_MAPPING = {
     'TenantInfo': (TenantInfo, 'tenant_id', 'ralph3_tenant_id'),
     'DataCenterAsset': (AssetInfo, 'asset_id', 'ralph3_asset_id'),
     'VirtualServer': (VirtualInfo, 'device_id', 'ralph3_id'),
+    'VIPInfo': (VIPInfo, 'vip_id', 'external_id'),
 }
 
 

--- a/src/ralph_scrooge/migrations/0025_auto__add_field_vipinfo_external_id__chg_field_vipinfo_vip_id.py
+++ b/src/ralph_scrooge/migrations/0025_auto__add_field_vipinfo_external_id__chg_field_vipinfo_vip_id.py
@@ -1,0 +1,490 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'VIPInfo.external_id'
+        db.add_column(u'ralph_scrooge_vipinfo', 'external_id',
+                      self.gf('django.db.models.fields.IntegerField')(unique=True, null=True),
+                      keep_default=False)
+
+
+        # Changing field 'VIPInfo.vip_id'
+        db.alter_column(u'ralph_scrooge_vipinfo', 'vip_id', self.gf('django.db.models.fields.IntegerField')(unique=True, null=True))
+
+    def backwards(self, orm):
+        # Deleting field 'VIPInfo.external_id'
+        db.delete_column(u'ralph_scrooge_vipinfo', 'external_id')
+
+
+        # User chose to not deal with backwards NULL issues for 'VIPInfo.vip_id'
+        raise RuntimeError("Cannot reverse this migration. 'VIPInfo.vip_id' and its values cannot be restored.")
+
+    models = {
+        'account.profile': {
+            'Meta': {'object_name': 'Profile'},
+            'activation_token': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'birth_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'company': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'cost_center': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'}),
+            'country': ('django.db.models.fields.PositiveIntegerField', [], {'default': '153'}),
+            'department': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'employee_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'gender': ('django.db.models.fields.PositiveIntegerField', [], {'default': '2'}),
+            'home_page': (u'dj.choices.fields.ChoiceField', [], {'unique': 'False', 'primary_key': 'False', 'db_column': 'None', 'blank': 'False', u'default': '1', 'null': 'False', '_in_south': 'True', 'db_index': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'}),
+            'manager': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'}),
+            'nick': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '30', 'blank': 'True'}),
+            'profit_center': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'}),
+            'segment': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'time_zone': ('django.db.models.fields.FloatField', [], {'default': '1.0'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'ralph_scrooge.assetinfo': {
+            'Meta': {'object_name': 'AssetInfo', '_ormbases': [u'ralph_scrooge.PricingObject']},
+            'asset_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'barcode': ('django.db.models.fields.CharField', [], {'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'device_id': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'pricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.PricingObject']", 'unique': 'True', 'primary_key': 'True'}),
+            'ralph3_asset_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'sn': ('django.db.models.fields.CharField', [], {'max_length': '200', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'warehouse': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.Warehouse']"})
+        },
+        u'ralph_scrooge.baseusage': {
+            'Meta': {'object_name': 'BaseUsage'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'divide_by': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '75', 'db_index': 'True'}),
+            'rounding': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'type': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'ralph_scrooge.businessline': {
+            'Meta': {'object_name': 'BusinessLine'},
+            'ci_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'ci_uid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '75'}),
+            'ralph3_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        u'ralph_scrooge.costdatestatus': {
+            'Meta': {'object_name': 'CostDateStatus'},
+            'accepted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'calculated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date': ('django.db.models.fields.DateField', [], {'unique': 'True'}),
+            'forecast_accepted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'forecast_calculated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'ralph_scrooge.dailyassetinfo': {
+            'Meta': {'object_name': 'DailyAssetInfo', '_ormbases': [u'ralph_scrooge.DailyPricingObject']},
+            'asset_info': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.AssetInfo']"}),
+            'daily_cost': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '16', 'decimal_places': '6'}),
+            'dailypricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.DailyPricingObject']", 'unique': 'True', 'primary_key': 'True'}),
+            'depreciation_rate': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '16', 'decimal_places': '6'}),
+            'is_depreciated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'price': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '16', 'decimal_places': '6'})
+        },
+        u'ralph_scrooge.dailycost': {
+            'Meta': {'object_name': 'DailyCost'},
+            'cost': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '16', 'decimal_places': '6'}),
+            'date': ('django.db.models.fields.DateField', [], {}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'forecast': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'pricing_object': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'daily_costs'", 'null': 'True', 'to': u"orm['ralph_scrooge.PricingObject']"}),
+            'service_environment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_costs'", 'to': u"orm['ralph_scrooge.ServiceEnvironment']"}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_costs'", 'to': u"orm['ralph_scrooge.BaseUsage']"}),
+            'value': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'warehouse': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'daily_costs'", 'null': 'True', 'to': u"orm['ralph_scrooge.Warehouse']"})
+        },
+        u'ralph_scrooge.dailydatabaseinfo': {
+            'Meta': {'object_name': 'DailyDatabaseInfo', '_ormbases': [u'ralph_scrooge.DailyPricingObject']},
+            'dailypricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.DailyPricingObject']", 'unique': 'True', 'primary_key': 'True'}),
+            'database_info': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_databases'", 'to': u"orm['ralph_scrooge.DatabaseInfo']"}),
+            'parent_device': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'daily_databases'", 'null': 'True', 'to': u"orm['ralph_scrooge.DailyAssetInfo']"})
+        },
+        u'ralph_scrooge.dailypricingobject': {
+            'Meta': {'unique_together': "((u'pricing_object', u'date'),)", 'object_name': 'DailyPricingObject'},
+            'date': ('django.db.models.fields.DateField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pricing_object': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_pricing_objects'", 'to': u"orm['ralph_scrooge.PricingObject']"}),
+            'service_environment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_pricing_objects'", 'to': u"orm['ralph_scrooge.ServiceEnvironment']"})
+        },
+        u'ralph_scrooge.dailytenantinfo': {
+            'Meta': {'object_name': 'DailyTenantInfo', '_ormbases': [u'ralph_scrooge.DailyPricingObject']},
+            'dailypricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.DailyPricingObject']", 'unique': 'True', 'primary_key': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'tenant_info': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_tenants'", 'to': u"orm['ralph_scrooge.TenantInfo']"})
+        },
+        u'ralph_scrooge.dailyusage': {
+            'Meta': {'object_name': 'DailyUsage'},
+            'daily_pricing_object': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.DailyPricingObject']"}),
+            'date': ('django.db.models.fields.DateField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'remarks': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'service_environment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_usages'", 'to': u"orm['ralph_scrooge.ServiceEnvironment']"}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.UsageType']"}),
+            'value': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'warehouse': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': u"orm['ralph_scrooge.Warehouse']", 'on_delete': 'models.PROTECT'})
+        },
+        u'ralph_scrooge.dailyvipinfo': {
+            'Meta': {'object_name': 'DailyVIPInfo', '_ormbases': [u'ralph_scrooge.DailyPricingObject']},
+            'dailypricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.DailyPricingObject']", 'unique': 'True', 'primary_key': 'True'}),
+            'ip_info': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'ip_daily_vips'", 'to': u"orm['ralph_scrooge.PricingObject']"}),
+            'vip_info': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_vips'", 'to': u"orm['ralph_scrooge.VIPInfo']"})
+        },
+        u'ralph_scrooge.dailyvirtualinfo': {
+            'Meta': {'object_name': 'DailyVirtualInfo', '_ormbases': [u'ralph_scrooge.DailyPricingObject']},
+            'dailypricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.DailyPricingObject']", 'unique': 'True', 'primary_key': 'True'}),
+            'hypervisor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'daily_virtuals'", 'null': 'True', 'to': u"orm['ralph_scrooge.DailyAssetInfo']"}),
+            'virtual_info': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'daily_virtuals'", 'to': u"orm['ralph_scrooge.VirtualInfo']"})
+        },
+        u'ralph_scrooge.databaseinfo': {
+            'Meta': {'object_name': 'DatabaseInfo', '_ormbases': [u'ralph_scrooge.PricingObject']},
+            'database_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True'}),
+            'parent_device': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'databases'", 'null': 'True', 'to': u"orm['ralph_scrooge.AssetInfo']"}),
+            'pricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.PricingObject']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'ralph_scrooge.dynamicextracost': {
+            'Meta': {'object_name': 'DynamicExtraCost'},
+            'cost': ('django.db.models.fields.DecimalField', [], {'max_digits': '16', 'decimal_places': '6'}),
+            'dynamic_extra_cost_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'costs'", 'to': u"orm['ralph_scrooge.DynamicExtraCostType']"}),
+            'end': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'forecast_cost': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '16', 'decimal_places': '6'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'start': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        },
+        u'ralph_scrooge.dynamicextracostdivision': {
+            'Meta': {'object_name': 'DynamicExtraCostDivision'},
+            'dynamic_extra_cost_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'division'", 'to': u"orm['ralph_scrooge.DynamicExtraCostType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percent': ('django.db.models.fields.FloatField', [], {'default': '100'}),
+            'usage_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'dynamic_extra_cost_division'", 'to': u"orm['ralph_scrooge.UsageType']"})
+        },
+        u'ralph_scrooge.dynamicextracosttype': {
+            'Meta': {'object_name': 'DynamicExtraCostType', '_ormbases': [u'ralph_scrooge.BaseUsage']},
+            'baseusage_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.BaseUsage']", 'unique': 'True', 'primary_key': 'True'}),
+            'excluded_services': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "u'excluded_from_dynamic_usage_types'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['ralph_scrooge.Service']"})
+        },
+        u'ralph_scrooge.environment': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'Environment'},
+            'ci_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'ci_uid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '75'}),
+            'ralph3_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        u'ralph_scrooge.extracost': {
+            'Meta': {'object_name': 'ExtraCost'},
+            'cost': ('django.db.models.fields.DecimalField', [], {'max_digits': '16', 'decimal_places': '6'}),
+            'end': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'extra_cost_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.ExtraCostType']"}),
+            'forecast_cost': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '16', 'decimal_places': '6'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'remarks': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'service_environment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'extra_costs'", 'to': u"orm['ralph_scrooge.ServiceEnvironment']"}),
+            'start': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        },
+        u'ralph_scrooge.extracosttype': {
+            'Meta': {'object_name': 'ExtraCostType', '_ormbases': [u'ralph_scrooge.BaseUsage']},
+            'baseusage_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.BaseUsage']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'ralph_scrooge.historicalservice': {
+            'Meta': {'ordering': "(u'-history_date', u'-history_id')", 'object_name': 'HistoricalService'},
+            u'active_from': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'active_to': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(9999, 12, 31, 0, 0)'}),
+            'cache_version': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'ci_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'ci_uid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            u'history_date': ('django.db.models.fields.DateTimeField', [], {}),
+            u'history_id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'history_type': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            u'history_user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'blank': 'True'}),
+            'manually_allocate_costs': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'pricing_service': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'+'", 'null': 'True', 'to': u"orm['ralph_scrooge.PricingService']"}),
+            'profit_center': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'related_name': "u'+'", 'to': u"orm['ralph_scrooge.ProfitCenter']"}),
+            'ralph3_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'})
+        },
+        u'ralph_scrooge.owner': {
+            'Meta': {'ordering': "[u'profile__nick']", 'object_name': 'Owner'},
+            'cache_version': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'cmdb_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'profile': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['account.Profile']", 'unique': 'True'})
+        },
+        u'ralph_scrooge.pricingobject': {
+            'Meta': {'object_name': 'PricingObject'},
+            'cache_version': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'pricing_objects'", 'null': 'True', 'to': u"orm['ralph_scrooge.PricingObjectModel']"}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'remarks': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'service_environment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'pricing_objects'", 'to': u"orm['ralph_scrooge.ServiceEnvironment']"}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'default': '255', 'related_name': "u'pricing_objects'", 'to': u"orm['ralph_scrooge.PricingObjectType']"})
+        },
+        u'ralph_scrooge.pricingobjectmodel': {
+            'Meta': {'ordering': "[u'manufacturer', u'name']", 'unique_together': "((u'model_id', u'type'),)", 'object_name': 'PricingObjectModel'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'ralph3_model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'default': '255', 'related_name': "u'pricing_object_models'", 'to': u"orm['ralph_scrooge.PricingObjectType']"})
+        },
+        u'ralph_scrooge.pricingobjecttype': {
+            'Meta': {'object_name': 'PricingObjectType'},
+            'color': ('django.db.models.fields.CharField', [], {'max_length': '30', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'icon_class': ('django.db.models.fields.CharField', [], {'default': "u'fa-tasks'", 'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'ralph_scrooge.pricingservice': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'PricingService', '_ormbases': [u'ralph_scrooge.BaseUsage']},
+            'baseusage_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.BaseUsage']", 'unique': 'True', 'primary_key': 'True'}),
+            'charge_diff_to_real_costs': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'charged_by_diffs'", 'null': 'True', 'to': u"orm['ralph_scrooge.PricingService']"}),
+            'excluded_base_usage_types': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "u'excluded_from_pricing_service'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['ralph_scrooge.UsageType']"}),
+            'excluded_services': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "u'excluded_from_pricing_services'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['ralph_scrooge.Service']"}),
+            'plugin_type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'regular_usage_types': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "u'pricing_services'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['ralph_scrooge.UsageType']"}),
+            'usage_types': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "u'services'", 'symmetrical': 'False', 'through': u"orm['ralph_scrooge.ServiceUsageTypes']", 'to': u"orm['ralph_scrooge.UsageType']"})
+        },
+        u'ralph_scrooge.profitcenter': {
+            'Meta': {'object_name': 'ProfitCenter'},
+            'business_line': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'related_name': "u'profit_centers'", 'to': u"orm['ralph_scrooge.BusinessLine']"}),
+            'ci_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'ci_uid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '75'}),
+            'ralph3_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        u'ralph_scrooge.service': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'Service'},
+            'cache_version': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'ci_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'ci_uid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'environments': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "u'services'", 'symmetrical': 'False', 'through': u"orm['ralph_scrooge.ServiceEnvironment']", 'to': u"orm['ralph_scrooge.Environment']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'manually_allocate_costs': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'ownership': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "u'services'", 'symmetrical': 'False', 'through': u"orm['ralph_scrooge.ServiceOwnership']", 'to': u"orm['ralph_scrooge.Owner']"}),
+            'pricing_service': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'services'", 'null': 'True', 'to': u"orm['ralph_scrooge.PricingService']"}),
+            'profit_center': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'related_name': "u'services'", 'to': u"orm['ralph_scrooge.ProfitCenter']"}),
+            'ralph3_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'})
+        },
+        u'ralph_scrooge.serviceenvironment': {
+            'Meta': {'ordering': "[u'service__name', u'environment__name']", 'unique_together': "((u'service', u'environment'),)", 'object_name': 'ServiceEnvironment'},
+            'environment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'services_environments'", 'to': u"orm['ralph_scrooge.Environment']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'environments_services'", 'to': u"orm['ralph_scrooge.Service']"})
+        },
+        u'ralph_scrooge.serviceownership': {
+            'Meta': {'unique_together': "((u'owner', u'service', u'type'),)", 'object_name': 'ServiceOwnership'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.Owner']"}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.Service']"}),
+            'type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'ralph_scrooge.serviceusagetypes': {
+            'Meta': {'unique_together': "((u'usage_type', u'pricing_service', u'start', u'end'),)", 'object_name': 'ServiceUsageTypes'},
+            'end': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(9999, 12, 31, 0, 0)'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percent': ('django.db.models.fields.FloatField', [], {'default': '100'}),
+            'pricing_service': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.PricingService']"}),
+            'start': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(1, 1, 1, 0, 0)'}),
+            'usage_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'service_division'", 'to': u"orm['ralph_scrooge.UsageType']"})
+        },
+        u'ralph_scrooge.statement': {
+            'Meta': {'unique_together': "((u'start', u'end', u'forecast', u'is_active'),)", 'object_name': 'Statement'},
+            'data': ('django.db.models.fields.TextField', [], {}),
+            'end': ('django.db.models.fields.DateField', [], {}),
+            'forecast': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'header': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'start': ('django.db.models.fields.DateField', [], {})
+        },
+        u'ralph_scrooge.supportcost': {
+            'Meta': {'object_name': 'SupportCost'},
+            'cost': ('django.db.models.fields.DecimalField', [], {'max_digits': '16', 'decimal_places': '6'}),
+            'end': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'extra_cost_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.ExtraCostType']"}),
+            'forecast_cost': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '16', 'decimal_places': '6'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'pricing_object': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.PricingObject']"}),
+            'remarks': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'start': ('django.db.models.fields.DateField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'support_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'ralph_scrooge.syncstatus': {
+            'Meta': {'unique_together': "((u'date', u'plugin'),)", 'object_name': 'SyncStatus'},
+            'cache_version': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date': ('django.db.models.fields.DateField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'plugin': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'remarks': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'success': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'ralph_scrooge.team': {
+            'Meta': {'object_name': 'Team', '_ormbases': [u'ralph_scrooge.BaseUsage']},
+            'baseusage_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.BaseUsage']", 'unique': 'True', 'primary_key': 'True'}),
+            'billing_type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'cache_version': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'excluded_services': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "u'excluded_teams'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['ralph_scrooge.Service']"}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'show_percent_column': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'ralph_scrooge.teamcost': {
+            'Meta': {'object_name': 'TeamCost'},
+            'cost': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '16', 'decimal_places': '6'}),
+            'end': ('django.db.models.fields.DateField', [], {}),
+            'forecast_cost': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '16', 'decimal_places': '6'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'members_count': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True', 'blank': 'True'}),
+            'start': ('django.db.models.fields.DateField', [], {}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.Team']"})
+        },
+        u'ralph_scrooge.teammanager': {
+            'Meta': {'unique_together': "((u'manager', u'team'),)", 'object_name': 'TeamManager'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'manager': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.Owner']"}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.Team']"})
+        },
+        u'ralph_scrooge.teamserviceenvironmentpercent': {
+            'Meta': {'unique_together': "((u'team_cost', u'service_environment'),)", 'object_name': 'TeamServiceEnvironmentPercent'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percent': ('django.db.models.fields.FloatField', [], {}),
+            'service_environment': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.ServiceEnvironment']"}),
+            'team_cost': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'percentage'", 'to': u"orm['ralph_scrooge.TeamCost']"})
+        },
+        u'ralph_scrooge.tenantinfo': {
+            'Meta': {'object_name': 'TenantInfo', '_ormbases': [u'ralph_scrooge.PricingObject']},
+            'device_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'pricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.PricingObject']", 'unique': 'True', 'primary_key': 'True'}),
+            'ralph3_tenant_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'tenant_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100', 'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        u'ralph_scrooge.usageprice': {
+            'Meta': {'ordering': "(u'type', u'-start')", 'object_name': 'UsagePrice'},
+            'cost': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '16', 'decimal_places': '6'}),
+            'end': ('django.db.models.fields.DateField', [], {}),
+            'forecast_cost': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '16', 'decimal_places': '6'}),
+            'forecast_price': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '16', 'decimal_places': '6'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'price': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '16', 'decimal_places': '6'}),
+            'start': ('django.db.models.fields.DateField', [], {}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.UsageType']"}),
+            'warehouse': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['ralph_scrooge.Warehouse']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'})
+        },
+        u'ralph_scrooge.usagetype': {
+            'Meta': {'object_name': 'UsageType', '_ormbases': [u'ralph_scrooge.BaseUsage']},
+            'average': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'baseusage_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.BaseUsage']", 'unique': 'True', 'primary_key': 'True'}),
+            'by_cost': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'by_warehouse': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'excluded_services': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "u'excluded_usage_types'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['ralph_scrooge.Service']"}),
+            'is_manually_type': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'show_value_percentage': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'usage_type': ('django.db.models.fields.CharField', [], {'default': "u'SU'", 'max_length': '2'})
+        },
+        u'ralph_scrooge.vipinfo': {
+            'Meta': {'object_name': 'VIPInfo', '_ormbases': [u'ralph_scrooge.PricingObject']},
+            'external_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True'}),
+            'ip_info': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'vip'", 'to': u"orm['ralph_scrooge.PricingObject']"}),
+            'load_balancer': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'vips'", 'null': 'True', 'to': u"orm['ralph_scrooge.PricingObject']"}),
+            'port': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'pricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.PricingObject']", 'unique': 'True', 'primary_key': 'True'}),
+            'vip_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True'})
+        },
+        u'ralph_scrooge.virtualinfo': {
+            'Meta': {'object_name': 'VirtualInfo', '_ormbases': [u'ralph_scrooge.PricingObject']},
+            'device_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True'}),
+            'pricingobject_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['ralph_scrooge.PricingObject']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'ralph_scrooge.warehouse': {
+            'Meta': {'object_name': 'Warehouse'},
+            'cache_version': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'id_from_assets': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'+'", 'on_delete': 'models.SET_NULL', 'default': 'None', 'to': "orm['account.Profile']", 'blank': 'True', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '75', 'db_index': 'True'}),
+            'ralph3_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'show_in_report': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['ralph_scrooge']

--- a/src/ralph_scrooge/models/pricing_object.py
+++ b/src/ralph_scrooge/models/pricing_object.py
@@ -404,9 +404,11 @@ class DailyTenantInfo(DailyPricingObject):
 
 
 class VIPInfo(PricingObject):
-    vip_id = db.IntegerField(unique=True, verbose_name=_("Ralph VIP ID"))
+    vip_id = db.IntegerField(
+        unique=True, null=True, verbose_name=_("Ralph VIP ID")
+    )
     external_id = db.IntegerField(
-        unique=True, verbose_name=_("VIP ID from external system")
+        unique=True, null=True, verbose_name=_("VIP ID from external system")
     )
     ip_info = db.ForeignKey(
         PricingObject,

--- a/src/ralph_scrooge/models/pricing_object.py
+++ b/src/ralph_scrooge/models/pricing_object.py
@@ -405,6 +405,9 @@ class DailyTenantInfo(DailyPricingObject):
 
 class VIPInfo(PricingObject):
     vip_id = db.IntegerField(unique=True, verbose_name=_("Ralph VIP ID"))
+    external_id = db.IntegerField(
+        unique=True, verbose_name=_("VIP ID from external system")
+    )
     ip_info = db.ForeignKey(
         PricingObject,
         related_name='vip',

--- a/src/ralph_scrooge/plugins/collect/ralph3_asset.py
+++ b/src/ralph_scrooge/plugins/collect/ralph3_asset.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from decimal import Decimal as D
 
 from dateutil.relativedelta import relativedelta
-from django.conf import settings
 from django.db import IntegrityError
 from django.db.transaction import commit_on_success
 

--- a/src/ralph_scrooge/plugins/collect/ralph3_vip.py
+++ b/src/ralph_scrooge/plugins/collect/ralph3_vip.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@plugin.register(
+    chain='scrooge',
+    requires=['ralph3_service_environment', 'ralph3_asset']
+)
+def ralph3_vip(today, **kwargs):
+    pass

--- a/src/ralph_scrooge/plugins/collect/utils.py
+++ b/src/ralph_scrooge/plugins/collect/utils.py
@@ -13,6 +13,7 @@ from ralph_scrooge.plugins.collect._exceptions import (
 from django.conf import settings
 import requests
 
+
 # TODO(xor-xor): Move this module from plugins.collect to plugins, since it is
 # used both by collect and subscribers packages.
 

--- a/src/ralph_scrooge/plugins/collect/utils.py
+++ b/src/ralph_scrooge/plugins/collect/utils.py
@@ -6,6 +6,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from ralph_scrooge.models import ServiceEnvironment
+from ralph_scrooge.plugins.collect._exceptions import (
+    UnknownServiceEnvironmentNotConfiguredError,
+)
 
 from django.conf import settings
 import requests

--- a/src/ralph_scrooge/plugins/collect/utils.py
+++ b/src/ralph_scrooge/plugins/collect/utils.py
@@ -13,6 +13,8 @@ from ralph_scrooge.plugins.collect._exceptions import (
 from django.conf import settings
 import requests
 
+# TODO(xor-xor): Move this module from plugins.collect to plugins, since it is
+# used both by collect and subscribers packages.
 
 # TODO(xor-xor): Add tests for this function once responses lib will
 # incorporate this bugfix: https://github.com/getsentry/responses/pull/109
@@ -53,6 +55,9 @@ def get_from_ralph(endpoint, logger, query=None, limit=100):
                 yield result
 
 
+# TODO(xor-xor): Add test(s) for this function.
+# TODO(xor-xor): Refactor other plugins (especially those with ralph3_ prefix)
+# to use this function for getting unknown service environment.
 def get_unknown_service_env(plugin_type, subtype=None):
     """We assume that settings.UNKNOWN_SERVICES_ENVIRONMENTS structure can be
     be nested by one level at most.

--- a/src/ralph_scrooge/plugins/subscribers/__init__.py
+++ b/src/ralph_scrooge/plugins/subscribers/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+import pkgutil
+
+
+for loader, name, ispkg in pkgutil.iter_modules(__path__, __name__ + '.'):
+    __import__(name, globals(), locals(), [], -1)

--- a/src/ralph_scrooge/plugins/subscribers/ralph3_vip.py
+++ b/src/ralph_scrooge/plugins/subscribers/ralph3_vip.py
@@ -52,10 +52,9 @@ def validate_vip_event_data(data):
     if not name:
         err = 'missing name'
         errors.append(err)
-    try:
-        IPAddress(address=ip).clean_fields()
-    except (TypeError, ValidationError):
-        err = 'invalid IP address "{}"'.format(ip)
+    if not ip:
+        err = 'missing IP address'
+        # unlike in Ralph3, we don't check if such address is valid!
         errors.append(err)
     if not port or port < 1024 or port > 49151:
         err = 'invalid port "{}"'.format(port)

--- a/src/ralph_scrooge/plugins/subscribers/ralph3_vip.py
+++ b/src/ralph_scrooge/plugins/subscribers/ralph3_vip.py
@@ -112,7 +112,7 @@ def get_service_env(event_data):
         )
     subtype = event_data['load_balancer_type']
     subtype = normalize_lb_type(subtype)
-    service_env = get_unknown_service_env('vip', subtype=subtype)  # XXX use 'ralph3_vip' instead
+    service_env = get_unknown_service_env('vip', subtype=subtype)  # XXX use 'ralph3_vip' instead of 'vip' in settings..?
     return (service_env, service_env_found)
 
 

--- a/src/ralph_scrooge/plugins/subscribers/vip.py
+++ b/src/ralph_scrooge/plugins/subscribers/vip.py
@@ -5,17 +5,187 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import datetime
 import logging
 
-from ralph_scrooge.models.pricing_object import VIPInfo
+from ralph_scrooge.models import (
+    PRICING_OBJECT_TYPES,
+    PricingObject,
+    PricingObjectModel,
+    ServiceEnvironment,
+    VIPInfo,
+)
+from ralph_scrooge.plugins.collect._exceptions import (
+    UnknownServiceEnvironmentNotConfiguredError,
+)
+from ralph_scrooge.plugins.collect.utils import get_unknown_service_env
 
 from pyhermes.decorators import subscriber
 
 logger = logging.getLogger(__name__)
 
 
+def validate_vip_event_data(data):
+    """Performs some basic sanity checks (e.g. missing values) on the incoming
+    event data. Returns list of errors (if any).
+
+    This function is copied from Ralph3 (data_center.subscribers), with slight
+    modifications.
+    """
+    id = data['id']
+    name = data['name']
+    ip = data['ip']
+    port = data['port']
+    protocol = data['protocol']
+    service = data['service']
+    if service:
+        service_uid = service.get('uid')
+    else:
+        service_uid = None
+    environment = data['environment']
+    lb_type = data['load_balancer_type']
+    errors = []
+
+    if not id:
+        err = 'missing id'
+        errors.append(err)
+    if not name:
+        err = 'missing name'
+        errors.append(err)
+    try:
+        IPAddress(address=ip).clean_fields()
+    except (TypeError, ValidationError):
+        err = 'invalid IP address "{}"'.format(ip)
+        errors.append(err)
+    if not port or port < 1024 or port > 49151:
+        err = 'invalid port "{}"'.format(port)
+        errors.append(err)
+    if not protocol:
+        err = 'missing protocol'
+        errors.append(err)
+    if not service_uid:
+        err = 'missing service UID'
+        errors.append(err)
+    if not environment:
+        err = 'missing environment'
+        errors.append(err)
+    if not lb_type:
+        err = 'missing load_balancer_type'
+        errors.append(err)
+    return errors
+
+
+def normalize_lb_type(lb_type):
+    # XXX(xor-xor): What about standarizing these names between external
+    # systems and settings..?
+    if lb_type == 'HAPROXY':
+        return 'HA Proxy'
+    else:
+        return lb_type.upper()
+
+
+def get_vip_model(event_data):
+    lb_type = normalize_lb_type(event_data['load_balancer_type'])
+    model = PricingObjectModel.objects.get_or_create(
+        # model_id=event_data['type_id'],  # XXX we don't have anything like that in the incoming event_data
+        name=lb_type,
+        type_id=PRICING_OBJECT_TYPES.VIP,
+    )[0]
+    # XXX do we need to fill ralph3_model_id field here as well..?
+    return model
+
+
+def get_service_env(event_data):
+    service_env_found = False
+    try:
+        service_env = ServiceEnvironment.objects.get(
+            service__ci_uid=event_data['service']['uid'],
+            environment__name=event_data['environment'],
+        )
+        service_env_found = True
+    except ServiceEnvironment.DoesNotExist:
+        msg = (
+            'ServiceEnvironment for service UID "{}" and environment "{}" '
+            'does not exist.'
+        )
+        logger.warning(
+            msg.format(event_data['service']['uid'], event_data['environment'])
+        )
+    subtype = event_data['load_balancer_type']
+    subtype = normalize_lb_type(subtype)
+    service_env = get_unknown_service_env('vip', subtype=subtype)  # XXX use 'ralph3_vip' instead
+    return (service_env, service_env_found)
+
+
+def save_vip_info(event_data):
+    service_env, service_env_found = get_service_env(event_data)
+    try:
+        vip_info = VIPInfo.objects.get(external_id=event_data['id'])
+    except VIPInfo.DoesNotExist:
+        # XXX @mkurek: there was a comment in old (Ralph2-based) vip plugin:
+        # "TODO(?): check if there is single PricingObject with given name
+        # first"
+        # - is it still valid..?
+        vip_info = VIPInfo(
+            external_id=event_data['id'],
+            type_id=PRICING_OBJECT_TYPES.VIP,
+        )
+
+    # get ip_info
+    ip_info = PricingObject.objects.get_or_create(
+        name=event_data['ip'],
+        type_id=PRICING_OBJECT_TYPES.IP_ADDRESS,
+        defaults=dict(service_environment=service_env)
+    )[0]
+    if service_env_found:
+        ip_info.service_environment = service_env
+    ip_info.save()
+
+    # fill necessary vip_info fields and finally save it
+    vip_info.model = get_vip_model(event_data)
+    vip_info.name = event_data['name']
+    vip_info.port = event_data['port']
+    vip_info.ip_info = ip_info
+    # We are temporarily null-ifying load_balancer field here, since there's no
+    # ralph3_asset_id (or anything like that) in the incoming event_data (yet).
+    vip_info.load_balancer = None
+    vip_info.service_environment = service_env
+    vip_info.save()
+    return vip_info
+
+
+def save_daily_vip_info(vip_info, date):
+    daily_vip_info = vip_info.get_daily_pricing_object(date)
+    daily_vip_info.service_environment = vip_info.service_environment
+    daily_vip_info.ip_info = vip_info.ip_info
+    daily_vip_info.save()
+    return daily_vip_info
+
+
 @subscriber(
     topic='refreshVipEvent',
 )
 def ralph3_vip(event_data):
-    print('=== OK! ===')
+    errors = validate_vip_event_data(event_data)
+    if errors:
+        msg = (
+            'Error(s) detected in event data: {}. Ignoring received '
+            'refreshVipEvent.'
+        )
+        logger.error(msg.format('; '.join(errors)))
+        return
+
+    # XXX @mkurek: since this plugin is not governed by plugin_runner, we have
+    # lost the ability to pass an arbitrary date here - is this OK for you..?
+    date = datetime.date.today()
+    try:
+        vip_info = save_vip_info(event_data)
+    except UnknownServiceEnvironmentNotConfiguredError:
+        msg = (
+            'Unknown service environment not configured for "ralph3_vip" '
+            'plugin'
+        )
+        logger.error(msg)
+        return
+
+    save_daily_vip_info(vip_info, date)

--- a/src/ralph_scrooge/plugins/subscribers/vip.py
+++ b/src/ralph_scrooge/plugins/subscribers/vip.py
@@ -104,9 +104,9 @@ def get_service_env(event_data):
         logger.warning(
             msg.format(event_data['service']['uid'], event_data['environment'])
         )
-    subtype = event_data['load_balancer_type']
-    subtype = normalize_lb_type(subtype)
-    service_env = get_unknown_service_env('vip', subtype=subtype)
+        subtype = event_data['load_balancer_type']
+        subtype = normalize_lb_type(subtype)
+        service_env = get_unknown_service_env('vip', subtype=subtype)
     return (service_env, service_env_found)
 
 
@@ -138,9 +138,6 @@ def save_vip_info(event_data):
     vip_info.name = event_data['name']
     vip_info.port = event_data['port']
     vip_info.ip_info = ip_info
-    # We are temporarily null-ifying load_balancer field here, since there's no
-    # ralph3_asset_id (or anything like that) in the incoming event_data (yet).
-    vip_info.load_balancer = None
     vip_info.service_environment = service_env
     vip_info.save()
     return vip_info
@@ -157,7 +154,7 @@ def save_daily_vip_info(vip_info, date):
 @subscriber(
     topic='refreshVipEvent',
 )
-def ralph3_vip(event_data):
+def vip(event_data):
     errors = validate_vip_event_data(event_data)
     if errors:
         msg = (
@@ -172,8 +169,7 @@ def ralph3_vip(event_data):
         vip_info = save_vip_info(event_data)
     except UnknownServiceEnvironmentNotConfiguredError:
         msg = (
-            'Unknown service environment not configured for "ralph3_vip" '
-            'plugin'
+            'Unknown service environment not configured for "vip" plugin'
         )
         logger.error(msg)
         return

--- a/src/ralph_scrooge/plugins/subscribers/vip.py
+++ b/src/ralph_scrooge/plugins/subscribers/vip.py
@@ -7,12 +7,15 @@ from __future__ import unicode_literals
 
 import logging
 
+from ralph_scrooge.models.pricing_object import VIPInfo
+
+from pyhermes.decorators import subscriber
+
 logger = logging.getLogger(__name__)
 
 
-@plugin.register(
-    chain='scrooge',
-    requires=['ralph3_service_environment', 'ralph3_asset']
+@subscriber(
+    topic='refreshVipEvent',
 )
-def ralph3_vip(today, **kwargs):
-    pass
+def ralph3_vip(event_data):
+    print('=== OK! ===')

--- a/src/ralph_scrooge/settings.py
+++ b/src/ralph_scrooge/settings.py
@@ -181,3 +181,7 @@ COMPONENTS_TABLE_SCHEMA = {
         'model': 'ralph_scrooge.models.DailyDatabaseInfo',
     },
 }
+
+LOAD_BALANCER_TYPES_MAPPING = {
+    'HAPROXY': 'HA Proxy',
+}

--- a/src/ralph_scrooge/tests/plugins/subscribers/test_vip.py
+++ b/src/ralph_scrooge/tests/plugins/subscribers/test_vip.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import datetime
+from copy import deepcopy
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from ralph_scrooge.models import PRICING_OBJECT_TYPES
+from ralph_scrooge.plugins.subscribers.vip import (
+    validate_vip_event_data,
+    normalize_lb_type,
+    get_vip_model,
+    get_service_env,
+    save_vip_info,
+    save_daily_vip_info,
+)
+from ralph_scrooge.tests.utils.factory import (
+    AssetInfoFactory,
+    PricingObjectFactory,
+    PricingObjectModelFactory,
+    ServiceEnvironmentFactory,
+    VIPInfoFactory,
+)
+
+VIP_TYPES = ['HA Proxy', 'F5']
+UNKNOWN_SERVICE_ENVIRONMENT = ('xx-456', 'test')
+TEST_SETTINGS_UNKNOWN_SERVICE_ENVIRONMENTS = dict(
+    UNKNOWN_SERVICES_ENVIRONMENTS={
+        'vip': {
+            VIP_TYPES[0]: UNKNOWN_SERVICE_ENVIRONMENT,
+        }
+    },
+    VIP_TYPES=VIP_TYPES,
+)
+
+EVENT_DATA = {
+    "non_http": False,
+    "load_balancer": "test-lb.local",
+    "id": 111,
+    "service": {
+        "uid": "xx-123",
+        "name": "test service"
+    },
+    "load_balancer_type": "HAPROXY",
+    "port": 8000,
+    "name": "ralph-test.local_8000",
+    "environment": "test",
+    "venture": None,
+    "protocol": "TCP",
+    "partition": "default",
+    "ip": "10.20.30.40"
+}
+
+
+class ValidateEventDataTestCase(TestCase):
+
+    def setUp(self):
+        self.event_data = deepcopy(EVENT_DATA)
+
+    def test_missing_id(self):
+        self.event_data['id'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing id', errors)
+
+    def test_missing_name(self):
+        self.event_data['name'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing name', errors)
+
+    def test_missing_ip_address(self):
+        self.event_data['ip'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing IP address', errors)
+
+    def test_invalid_port(self):
+        self.event_data['port'] = 80
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('invalid port "80"', errors)
+
+        self.event_data['port'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('invalid port "None"', errors)
+
+    def test_missing_protocol(self):
+        self.event_data['protocol'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing protocol', errors)
+
+    def test_missing_service_uid(self):
+        self.event_data['service']['uid'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing service UID', errors)
+
+        self.event_data['service'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing service UID', errors)
+
+    def test_missing_environment(self):
+        self.event_data['environment'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing environment', errors)
+
+    def test_missing_load_balancer_type(self):
+        self.event_data['load_balancer_type'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('missing load_balancer_type', errors)
+
+    def test_if_errors_aggregate(self):
+        self.event_data['service'] = None
+        self.event_data['environment'] = None
+        errors = validate_vip_event_data(self.event_data)
+        self.assertEqual(len(errors), 2)
+        self.assertIn('missing service UID', errors)
+        self.assertIn('missing environment', errors)
+
+
+class TestVIPSubscribersPlugin(TestCase):
+
+    # TODO(xor-xor): Set check_load_balancer=True as a default value when it
+    # will be clear what to do with VIPInfo.load_balancer field.
+    def _compare_vips(self, vip_info, event_data, check_load_balancer=False):
+        self.assertEquals(vip_info.external_id, event_data['id'])
+        self.assertEquals(vip_info.name, event_data['name'])
+        self.assertEquals(vip_info.port, event_data['port'])
+        self.assertEquals(vip_info.ip_info.name, event_data['ip'])
+        self.assertEquals(
+            vip_info.model.name,
+            normalize_lb_type(event_data['load_balancer_type']),
+        )
+        self.assertEquals(vip_info.type_id, PRICING_OBJECT_TYPES.VIP)
+        if check_load_balancer:
+            self.assertEquals(vip_info.load_balancer, self.load_balancer)
+
+    def setUp(self):
+        self.today = datetime.date.today()
+        self.event_data = deepcopy(EVENT_DATA)
+        self.model = PricingObjectModelFactory(
+            name='HA Proxy',
+            type_id=PRICING_OBJECT_TYPES.VIP,
+        )
+        self.service_env = ServiceEnvironmentFactory(
+            service__ci_uid=self.event_data['service']['uid'],
+            environment__name=self.event_data['environment'],
+        )
+        self.unknown_service_env = ServiceEnvironmentFactory(
+            service__ci_uid=UNKNOWN_SERVICE_ENVIRONMENT[0],
+            environment__name=UNKNOWN_SERVICE_ENVIRONMENT[1],
+        )
+        self.load_balancer = AssetInfoFactory()
+
+    def test_normalize_lb_type(self):
+        lb_type = normalize_lb_type('HAPROXY')
+        self.assertEqual(lb_type, 'HA Proxy')
+        lb_type = normalize_lb_type('F5')
+        self.assertEqual(lb_type, 'F5')
+
+    def test_get_vip_model(self):
+        model = get_vip_model(self.event_data)
+        self.assertEquals(model, self.model)
+
+    @override_settings(**TEST_SETTINGS_UNKNOWN_SERVICE_ENVIRONMENTS)
+    def test_get_known_service_env(self):
+        service_env, service_env_found = get_service_env(self.event_data)
+        self.assertEqual(service_env, self.service_env)
+        self.assertTrue(service_env_found)
+
+    @override_settings(**TEST_SETTINGS_UNKNOWN_SERVICE_ENVIRONMENTS)
+    def test_get_unknown_service_env(self):
+        self.event_data['service']['uid'] = 'non-existing uid'
+        service_env, service_env_found = get_service_env(self.event_data)
+        self.assertEqual(service_env, self.unknown_service_env)
+        self.assertFalse(service_env_found)
+
+    def test_save_vip_info(self):
+        vip_info = save_vip_info(self.event_data)
+        self.assertEquals(
+            vip_info.service_environment,
+            self.service_env,
+        )
+        self.assertEquals(
+            vip_info.ip_info.service_environment,
+            self.service_env,
+        )
+        self._compare_vips(vip_info, self.event_data)
+
+    def test_save_vip_info_ip_exists(self):
+        ip_info = PricingObjectFactory(
+            name=self.event_data['ip'],
+            type_id=PRICING_OBJECT_TYPES.IP_ADDRESS,
+        )
+        vip_info = save_vip_info(self.event_data)
+        self._compare_vips(vip_info, self.event_data)
+        self.assertEquals(ip_info.id, vip_info.ip_info.id)
+
+    def test_save_vip_info_vip_exists(self):
+        existing_vip_info = VIPInfoFactory(external_id=self.event_data['id'])
+        vip_info = save_vip_info(self.event_data)
+        self._compare_vips(vip_info, self.event_data)
+        self.assertEquals(existing_vip_info.id, vip_info.id)
+
+    @override_settings(**TEST_SETTINGS_UNKNOWN_SERVICE_ENVIRONMENTS)
+    def test_save_vip_info_invalid_service_environment(self):
+        service_env = ServiceEnvironmentFactory.build()
+        self.event_data['service']['uid'] = service_env.service.ci_uid
+        self.event_data['environment'] = service_env.environment.name
+        vip_info = save_vip_info(self.event_data)
+        self._compare_vips(vip_info, self.event_data)
+        self.assertEquals(
+            vip_info.service_environment,
+            self.unknown_service_env
+        )
+        self.assertEquals(
+            vip_info.ip_info.service_environment,
+            self.unknown_service_env
+        )
+
+    def test_save_daily_vip_info(self):
+        vip_info = VIPInfoFactory()
+        daily_vip_info = save_daily_vip_info(vip_info, self.today)
+        self.assertEquals(daily_vip_info.vip_info, vip_info)
+        self.assertEquals(daily_vip_info.pricing_object, vip_info)
+        self.assertEquals(daily_vip_info.date, self.today)
+        self.assertEquals(
+            daily_vip_info.service_environment,
+            vip_info.service_environment
+        )

--- a/src/ralph_scrooge/urls.py
+++ b/src/ralph_scrooge/urls.py
@@ -10,7 +10,7 @@ from django.contrib.auth.decorators import login_required
 from rest_framework import routers
 from tastypie.api import Api
 
-import ralph_scrooge.plugins.subscribers  # XXX
+import ralph_scrooge.plugins.subscribers  # XXX is it OK to leave this like that (with #noqa maybe)..?
 from ralph_scrooge.api import PricingServiceUsageResource, SyncStatusViewSet
 from ralph_scrooge.views.bootstrapangular import (
     BootstrapAngular,

--- a/src/ralph_scrooge/urls.py
+++ b/src/ralph_scrooge/urls.py
@@ -132,7 +132,14 @@ urlpatterns = patterns(
     ),
 )
 
-urlpatterns += patterns(
-    '',
-    url(r'^hermes/', include('pyhermes.apps.django.urls'))
-)
+# TODO(xor-xor): Uncomment patterns for hermes below once Scrooge will be
+# completely separated from Ralph. And remember, that endpoint for
+# refreshVipEvent subscription will change from:
+# /hermes/events/refreshVipEvent/
+# to:
+# /scrooge/hermes/events/refreshVipEvent/.
+#
+# urlpatterns += patterns(
+#     '',
+#     url(r'^hermes/', include('pyhermes.apps.django.urls'))
+# )

--- a/src/ralph_scrooge/urls.py
+++ b/src/ralph_scrooge/urls.py
@@ -10,7 +10,7 @@ from django.contrib.auth.decorators import login_required
 from rest_framework import routers
 from tastypie.api import Api
 
-import ralph_scrooge.plugins.subscribers  # XXX is it OK to leave this like that (with #noqa maybe)..?
+import ralph_scrooge.plugins.subscribers  # noqa: F401
 from ralph_scrooge.api import PricingServiceUsageResource, SyncStatusViewSet
 from ralph_scrooge.views.bootstrapangular import (
     BootstrapAngular,

--- a/src/ralph_scrooge/urls.py
+++ b/src/ralph_scrooge/urls.py
@@ -10,6 +10,7 @@ from django.contrib.auth.decorators import login_required
 from rest_framework import routers
 from tastypie.api import Api
 
+import ralph_scrooge.plugins.subscribers  # XXX
 from ralph_scrooge.api import PricingServiceUsageResource, SyncStatusViewSet
 from ralph_scrooge.views.bootstrapangular import (
     BootstrapAngular,
@@ -24,7 +25,7 @@ from ralph_scrooge.views.monthly_costs import MonthlyCosts
 from ralph_scrooge.views.report_services_changes import ServicesChangesReportView  # noqa
 from ralph_scrooge.views.report_services_costs import ServicesCostsReportView
 from ralph_scrooge.views.report_services_usages import ServicesUsagesReportView  # noqa
-
+from ralph_scrooge.rest import left_menu
 from ralph_scrooge.utils.security import scrooge_permission
 
 v09_api = Api(api_name='v0.9')
@@ -129,4 +130,9 @@ urlpatterns = patterns(
         scrooge_permission(CollectPlugins.as_view()),
         name='collect_plugins',
     ),
+)
+
+urlpatterns += patterns(
+    '',
+    url(r'^hermes/', include('pyhermes.apps.django.urls'))
 )

--- a/src/ralph_scrooge/urls.py
+++ b/src/ralph_scrooge/urls.py
@@ -25,7 +25,7 @@ from ralph_scrooge.views.monthly_costs import MonthlyCosts
 from ralph_scrooge.views.report_services_changes import ServicesChangesReportView  # noqa
 from ralph_scrooge.views.report_services_costs import ServicesCostsReportView
 from ralph_scrooge.views.report_services_usages import ServicesUsagesReportView  # noqa
-from ralph_scrooge.rest import left_menu
+
 from ralph_scrooge.utils.security import scrooge_permission
 
 v09_api = Api(api_name='v0.9')


### PR DESCRIPTION
This PR provides a new plugin for VIPs, which is kind of different than the rest, because it is more of a view than a plugin launched from comand line. It basically provides a dedicated endpoint, subscribes it to `refreshVipEvent` in Hermes and processes received data in real time, so in contrast to "normal" plugins, there's no distinction when it starts/finishes.

It also makes `get_unknown_service_env` function more generic, and moves it  to `plugins.collect.utils` (from `ralph3_asset` plugin).
