### PR TITLE
Set lowest possible port for VIP to 0

### DIFF
--- a/src/ralph_scrooge/plugins/subscribers/vip.py
+++ b/src/ralph_scrooge/plugins/subscribers/vip.py
@@ -57,7 +57,7 @@ def validate_vip_event_data(data):
         err = 'missing IP address'
         # unlike in Ralph3, we don't check if such address is valid!
         errors.append(err)
-    if not isinstance(port, (int, long)) or port < 1 or port > 65535:
+    if not isinstance(port, (int, long)) or port < 0 or port > 65535:
         err = 'invalid port "{}"'.format(port)
         errors.append(err)
     if not protocol:


### PR DESCRIPTION
For some specific load balancers types, min port could be 0 (and it could be treated as "wildcard")
