### PR TITLE
Fix parsing end date in usages report

### DIFF
--- a/src/ralph_scrooge/rest/reports.py
+++ b/src/ralph_scrooge/rest/reports.py
@@ -110,7 +110,7 @@ class BaseReportContent(APIView):
         for date in ['start', 'end']:
             try:
                 params[date] = dateutil.parser.parse(
-                    request.QUERY_PARAMS.get('start')
+                    request.QUERY_PARAMS.get(date)
                 )
             except ValueError:
                 raise ParseError('Invalid value for {} param'.format(


### PR DESCRIPTION
Take end date instead of start (before, report was generated for one-day-only)
