### PR TITLE
Fix PricingObjectModel model_id field migration (nullability)

### DIFF
--- a/src/ralph_scrooge/migrations/0027_auto__chg_field_pricingobjectmodel_model_id.py
+++ b/src/ralph_scrooge/migrations/0027_auto__chg_field_pricingobjectmodel_model_id.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import datetime
+from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
@@ -8,22 +8,18 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        # Adding field 'VIPInfo.external_id'
-        db.add_column(u'ralph_scrooge_vipinfo', 'external_id',
-                      self.gf('django.db.models.fields.IntegerField')(unique=True, null=True),
-                      keep_default=False)
 
-
-        # Changing field 'VIPInfo.vip_id'
-        db.alter_column(u'ralph_scrooge_vipinfo', 'vip_id', self.gf('django.db.models.fields.IntegerField')(unique=True, null=True))
+        # Changing field 'PricingObjectModel.model_id'
+        db.alter_column(u'ralph_scrooge_pricingobjectmodel', 'model_id', self.gf('django.db.models.fields.IntegerField')(null=True))
 
     def backwards(self, orm):
-        # Deleting field 'VIPInfo.external_id'
-        db.delete_column(u'ralph_scrooge_vipinfo', 'external_id')
 
-
-        # User chose to not deal with backwards NULL issues for 'VIPInfo.vip_id'
-        raise RuntimeError("Cannot reverse this migration. 'VIPInfo.vip_id' and its values cannot be restored.")
+        # User chose to not deal with backwards NULL issues for 'PricingObjectModel.model_id'
+        raise RuntimeError("Cannot reverse this migration. 'PricingObjectModel.model_id' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'PricingObjectModel.model_id'
+        db.alter_column(u'ralph_scrooge_pricingobjectmodel', 'model_id', self.gf('django.db.models.fields.IntegerField')())
 
     models = {
         'account.profile': {
@@ -286,7 +282,7 @@ class Migration(SchemaMigration):
             'category': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'manufacturer': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
-            'model_id': ('django.db.models.fields.IntegerField', [], {}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
             'ralph3_model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
             'type': ('django.db.models.fields.related.ForeignKey', [], {'default': '255', 'related_name': "u'pricing_object_models'", 'to': u"orm['ralph_scrooge.PricingObjectType']"})


### PR DESCRIPTION
Somehow (?) between migrations 0007 and 0008, model_id of PricingObjectModel changed from beign not-null to null and it was reflected in south models dump, but there was no migration action making it nullable in database. This commit fixes it by removing info about null and blank from south models dump in the latest migration and creating new migration which make this field nullable in db.
