### PR TITLE
Post-update to Django 1.10 fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     zip_safe=False,  # because templates are loaded from file path
     install_requires=[
         'dj.choices==0.11.0',
-        'django-auth-ldap==1.1.3',
+        'django-auth-ldap==1.2.8',
         'django-filter==0.11',
         'django-nose==1.4.4',
         'django-rq==0.9.3',
@@ -40,7 +40,7 @@ setup(
         'django==1.10.2',
         'djangorestframework==3.5.0',
         'factory-boy==2.3.1',
-        'gunicorn==0.14.6',
+        'gunicorn==19.6.0',
         'ipaddr==2.1.11',
         'mock-django==0.6.6',
         'mock==0.8.0',

--- a/src/ralph_scrooge/__init__.py
+++ b/src/ralph_scrooge/__init__.py
@@ -1,1 +1,2 @@
 VERSION = ('3', '0', '1')
+default_app_config = 'ralph_scrooge.apps.ScroogeAppConfig'

--- a/src/ralph_scrooge/apps.py
+++ b/src/ralph_scrooge/apps.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class ScroogeAppConfig(AppConfig):
+    name = 'ralph_scrooge'
+    verbose_name = _('Scrooge')
+
+    def ready(self):
+        from ralph_scrooge.utils.ldap import register_callbacks
+        register_callbacks()

--- a/src/ralph_scrooge/settings/base.py
+++ b/src/ralph_scrooge/settings/base.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = [
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
+AUTH_USER_MODEL = 'ralph_scrooge.ScroogeUser'
 
 DATABASES = {
     'default': {
@@ -97,7 +98,6 @@ RQ_QUEUES = {
 for queue in RQ_QUEUE_LIST:
     RQ_QUEUES[queue] = dict(RQ_QUEUES['default'])
 
-AUTH_USER_MODEL = 'ralph_scrooge.ScroogeUser'
 
 CACHES = dict(
     default=dict(

--- a/src/ralph_scrooge/utils/ldap.py
+++ b/src/ralph_scrooge/utils/ldap.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 try:
     from django_auth_ldap.config import ActiveDirectoryGroupType
 except ImportError:
-    logger.warning('djang-auth-ldap not installed')
+    logger.warning('django-auth-ldap not installed')
 else:
     from django.core.cache import cache
     from django.conf import settings
@@ -95,7 +95,7 @@ def register_callbacks():
     try:
         from django_auth_ldap.backend import populate_user
     except ImportError:
-        logger.warning('djang-auth-ldap not installed')
+        logger.warning('django-auth-ldap not installed')
     else:
         @receiver(populate_user)
         def staff_superuser_populate(sender, user, ldap_user, **kwargs):

--- a/src/ralph_scrooge/utils/ldap_backend.py
+++ b/src/ralph_scrooge/utils/ldap_backend.py
@@ -1,0 +1,9 @@
+from django_auth_ldap import backend
+
+
+class ScroogeLDAPBackend(backend.LDAPBackend):
+    # add new settings - AUTH_LDAP_GROUP_MAPPING (django-auth-ldap will fetch
+    # it automatically from Scrooge settings)
+    default_settings = dict(
+        GROUP_MAPPING={}  # LDAP group -> Django group mapping
+    )

--- a/src/ralph_scrooge/wsgi.py
+++ b/src/ralph_scrooge/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for ralph project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.10/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ralph_scrooge.settings.prod")
+
+application = get_wsgi_application()


### PR DESCRIPTION
* use gunicorn in 19.6.0 version
* use django-auth-ldap in 1.2.8 version (Django 1.10 support)
* fix ldap utils (django_auth_ldap.backend cannot be imported directly in settings - Django apps aren't loaded yet)
* add wsgi script for gunicorn (run `gunicorn ralph_scrooge.wsgi`)