### PR TITLE
Remove populating user flags

### DIFF
--- a/src/ralph_scrooge/apps.py
+++ b/src/ralph_scrooge/apps.py
@@ -6,7 +6,3 @@ from django.utils.translation import ugettext_lazy as _
 class ScroogeAppConfig(AppConfig):
     name = 'ralph_scrooge'
     verbose_name = _('Scrooge')
-
-    def ready(self):
-        from ralph_scrooge.utils.ldap import register_callbacks
-        register_callbacks()

--- a/src/ralph_scrooge/utils/ldap.py
+++ b/src/ralph_scrooge/utils/ldap.py
@@ -21,7 +21,6 @@ except ImportError:
 else:
     from django.core.cache import cache
     from django.conf import settings
-    from django.dispatch import receiver
     from django.utils.encoding import force_unicode
 
     GROUP_CACHE_TIMEOUT = 1200
@@ -85,20 +84,3 @@ def get_ldap():
         settings.AUTH_LDAP_BIND_PASSWORD,
     )
     return conn
-
-
-def register_callbacks():
-    """
-    Register callback for populate_user event. This function should be called
-    when django apps are already loaded.
-    """
-    try:
-        from django_auth_ldap.backend import populate_user
-    except ImportError:
-        logger.warning('django-auth-ldap not installed')
-    else:
-        @receiver(populate_user)
-        def staff_superuser_populate(sender, user, ldap_user, **kwargs):
-            user.is_superuser = 'superuser' in ldap_user.group_names
-            user.is_staff = 'staff' in ldap_user.group_names
-            user.is_active = 'active' in ldap_user.group_names


### PR DESCRIPTION
There is no need to populate user flags on our own - if you need to populate 'is_active', 'is_staff' and 'is_superuser' use AUTH_LDAP_PROFILE_FLAGS_BY_GROUP settings (see https://pythonhosted.org/django-auth-ldap/users.html#easy-attributes for details).