### PR TITLE
Don't select related business_line for HistoricalService

### DIFF
--- a/src/ralph_scrooge/plugins/report/information.py
+++ b/src/ralph_scrooge/plugins/report/information.py
@@ -61,9 +61,7 @@ class Information(BaseReportPlugin):
                 'service',
                 flat=True
             ).distinct(),
-        ).select_related('business_line', 'profit_center').order_by(
-            'history_id'
-        )
+        ).select_related('profit_center').order_by('history_id')
         services = {}
         profit_centers = defaultdict(list)
         for service_history in services_history:


### PR DESCRIPTION
Django 1.4 seems to ignore this (error), Django 1.10 throws error here