### PR TITLE
Fix pricing-service-usages GET API - return only relevant usage types

### DIFF
--- a/src/ralph_scrooge/models/service.py
+++ b/src/ralph_scrooge/models/service.py
@@ -22,7 +22,7 @@ from ralph_scrooge.models.base import (
     BaseUsageType,
 )
 from ralph_scrooge.utils.models import EditorTrackable, Named, TimeTrackable
-from ralph_scrooge.models.usage import DailyUsage
+from ralph_scrooge.models.usage import DailyUsage, UsageType
 from ralph_scrooge.models.pricing_object import PRICING_OBJECT_TYPES
 
 
@@ -295,6 +295,16 @@ class PricingService(BaseUsage):
         # exclude self to prevent cycle
         ps = ps.exclude(id=self.id)
         return ps.distinct()
+
+    def get_usage_types_for_date(self, date):
+        """
+        Returns UsageTypes used by this pricing service on particular date.
+        """
+        return UsageType.objects.filter(
+            service_division__pricing_service=self,
+            service_division__start__lte=date,
+            service_division__end__gte=date,
+        )
 
 
 class ServiceUsageTypes(db.Model):

--- a/src/ralph_scrooge/rest/pricing_service_usages.py
+++ b/src/ralph_scrooge/rest/pricing_service_usages.py
@@ -345,7 +345,7 @@ def get_usages(usages_date, pricing_service):
     )
     usages_dict = defaultdict(list)
 
-    for usage_type in pricing_service.usage_types.all():
+    for usage_type in pricing_service.get_usage_types_for_date(usages_date):
         daily_usages = usage_type.dailyusage_set.filter(
             date=usages_date
         ).select_related(


### PR DESCRIPTION
Don't return all usage types used by this PricingService at any time - return only usage types valid for particular date.