### PR TITLE
Fix for missing/stale images in Swagger's styles.css

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ const del = require('del');
 const typescript = require('gulp-typescript');
 const tscConfig = require('./tsconfig.json');
 const sourcemaps = require('gulp-sourcemaps');
+const rename = require('gulp-rename');
 
 const mediaPath = 'src/ralph_scrooge/media/'
 const appPath = mediaPath + 'scrooge/'
@@ -113,6 +114,26 @@ gulp.task('clean_swagger', function () {
   return del(mediaPath + 'swagger/**');
 });
 
+// XXX These two tasks below are a temporary workaround for two files from
+// swagger-ui distribution that are either missing or have stale references in
+// style.css: logo.png and shield.png. And because of that, `scrooge collectstatic`
+// fails. Once we investigate this problem, these tasks should be removed (along
+// with `gulp-rename` package, which was added only for this purpose).
+gulp.task("swagger_fake_logo_png", ['swagger'], function() {
+    return gulp.src([
+        'images/logo_small.png',
+    ], {cwd: "node_modules/swagger-ui/dist/**"}) /* Glob required here. */
+    .pipe(rename('logo.png'))
+    .pipe(gulp.dest(mediaPath + "swagger/images/"));
+});
+gulp.task("swagger_fake_shield_png", ['swagger'], function() {
+    return gulp.src([
+        'images/logo_small.png',
+    ], {cwd: "node_modules/swagger-ui/dist/**"}) /* Glob required here. */
+    .pipe(rename('shield.png'))
+    .pipe(gulp.dest(mediaPath + "swagger/images/"));
+});
+
 gulp.task('default', function() {
-  gulp.start('compile', 'libs', 'swagger');
+    gulp.start('compile', 'libs', 'swagger_fake_logo_png', 'swagger_fake_shield_png');
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp": "3.9.1",
     "gulp-typescript": "^2.8.0",
     "gulp-sourcemaps": "1.6.0",
+    "gulp-rename": "1.2.2",
     "del": "^2.1.0",
     "@angular/common": "2.0.0-rc.1",
     "@angular/compiler": "2.0.0-rc.1",


### PR DESCRIPTION
Should be considered as a temporary workaround.