### PR TITLE
[API] service-environments-costs: Return total_costs as null when costs are not accepted

### DIFF
--- a/src/ralph_scrooge/rest_api/public/v0_10/service_environment_costs.py
+++ b/src/ralph_scrooge/rest_api/public/v0_10/service_environment_costs.py
@@ -385,7 +385,9 @@ def fetch_costs(
             # costs for particular date were accepted, but this service-env
             # does not have any costs then
             # TODO(mkurek): consider accepting only part of the month
-            # (currently only first day of month is checked)
+            # (currently only first day of month is checked when grouping by
+            # month - see if above - only first day of each month is placed in
+            # date_range_ )
             0 if date_ in filtered_dates else None
         )
         costs_for_date = {

--- a/src/ralph_scrooge/rest_api/public/v0_10/service_environment_costs.py
+++ b/src/ralph_scrooge/rest_api/public/v0_10/service_environment_costs.py
@@ -378,7 +378,16 @@ def fetch_costs(
             step=delta
         )
     for date_ in date_range_:
-        total_cost_for_date = total_costs.get(date_, 0)
+        total_cost_for_date = total_costs.get(
+            date_,
+            # None, when costs for particular date were not accepted (if
+            # accepted costs were requested) otherwise 0, which means, that
+            # costs for particular date were accepted, but this service-env
+            # does not have any costs then
+            # TODO(mkurek): consider accepting only part of the month
+            # (currently only first day of month is checked)
+            0 if date_ in filtered_dates else None
+        )
         costs_for_date = {
             'grouped_date': date_,
             'total_cost': round_safe(

--- a/src/ralph_scrooge/tests/rest_api/public/test_service_environment_costs.py
+++ b/src/ralph_scrooge/tests/rest_api/public/test_service_environment_costs.py
@@ -968,6 +968,7 @@ class TestServiceEnvironmentCosts(ScroogeTestCase):
             (10, 31, 20, 11),
             (11, 30, 40, 22),
         ]
+        # create (accepted) daily costs for every day of November and December
         for month, days, cost, usage in months:
             for day in range(1, days + 1):
                 date_as_str = '2016-{}-{}'.format(month, day)
@@ -1034,6 +1035,7 @@ class TestServiceEnvironmentCosts(ScroogeTestCase):
             (10, 31, 20, 11),
             (11, 30, 40, 22),
         ]
+        # create (accepted) daily costs for every day of November and December
         for month, days, cost, usage in months:
             for day in range(1, days + 1):
                 date_as_str = '2016-{}-{}'.format(month, day)


### PR DESCRIPTION
Return null instead of 0 for days (months), where costs were not accepted