### PR TITLE
Fix distributing pricing service cost when there is lack of some daily usages

### DIFF
--- a/src/ralph_scrooge/plugins/cost/pricing_service.py
+++ b/src/ralph_scrooge/plugins/cost/pricing_service.py
@@ -246,7 +246,7 @@ class PricingServiceBasePlugin(BaseCostPlugin):
             service_excluded = excluded_services.union(
                 service_usage_type.usage_type.excluded_services.all()
             )
-            usages_per_po = self._get_usages_per_pricing_object(
+            usages_per_pricing_object = self._get_usages_per_pricing_object(
                 usage_type=service_usage_type.usage_type,
                 date=date,
                 excluded_services=service_excluded,
@@ -255,8 +255,12 @@ class PricingServiceBasePlugin(BaseCostPlugin):
                 'service_environment',
             ).annotate(usage=Sum('value'))
             usage_type_id = service_usage_type.usage_type_id
-            for pricing_object, se, usage in usages_per_po:
-                usages[(pricing_object, se)][usage_type_id] = usage
+            for (
+                pricing_object, service_environment, usage
+            ) in usages_per_pricing_object:
+                usages[(
+                    pricing_object, service_environment
+                )][usage_type_id] = usage
 
             total_usages[usage_type_id] = self._get_total_usage(
                 usage_type=service_usage_type.usage_type,
@@ -265,13 +269,18 @@ class PricingServiceBasePlugin(BaseCostPlugin):
             )
             percentage[usage_type_id] = service_usage_type.percent
         # create hierarchy basing on usages
-        for (po, se), po_usages in usages.items():
-            po_usages_info = [
-                (value, total_usages[ut_id], percentage[ut_id])
-                for ut_id, value in po_usages.items()
+        for (
+            (pricing_object, service_environment),
+            pricing_object_usages
+        ) in usages.items():
+            pricing_object_usages_info = [
+                (value, total_usages[usage_type_id], percentage[usage_type_id])
+                for usage_type_id, value in pricing_object_usages.items()  # noqa: F812,E501
             ]
-            result[se].extend(
-                self._add_hierarchy_costs(po, po_usages_info, costs_hierarchy)
+            result[service_environment].extend(
+                self._add_hierarchy_costs(
+                    pricing_object, pricing_object_usages_info, costs_hierarchy
+                )
             )
         return result
 


### PR DESCRIPTION
When pricing service has multiple services (for distributing cost) and
not every DailyUsage is present (see #648 - ignoring zero-value usage)
costs were not distributed properly. It was caused by storying usage
values for single service environment on lists - these lists have
different size and when accessing by index (and using `zip` to
join this list with total usage and percentage for usage type)
usage value was combined with wrong total usage and percentage.